### PR TITLE
chore: update all SKILL.en.md files for takt v0.35.4

### DIFF
--- a/plugins/takt/skills/takt-analyzer/SKILL.en.md
+++ b/plugins/takt/skills/takt-analyzer/SKILL.en.md
@@ -1,46 +1,72 @@
 ---
 name: takt-analyzer
 description: >
-  A skill that analyzes existing TAKT pieces and facets, providing improvement suggestions.
-  Performs piece YAML structural validation, inter-facet consistency checks, style guide
+  A skill that analyzes existing TAKT workflows and facets, providing improvement suggestions.
+  Performs workflow YAML structural validation, inter-facet consistency checks, style guide
   compliance verification, unused facet detection, and rule design optimization proposals.
+  When execution logs (.takt/logs/*.jsonl) exist, also performs log-based diagnostic analysis,
+  reporting rule evaluation efficiency, loop hotspots, ABORT rates, etc.
   Uses references/takt style guides and engine specifications as analysis criteria.
-  Triggers: "analyze pieces", "check takt config", "facet quality check",
-  "review pieces", "takt analyze", "workflow improvement suggestions",
-  "piece consistency check", "find takt issues"
+  Triggers: "analyze workflows", "check takt config", "facet quality check",
+  "review workflows", "takt analyze", "workflow improvement suggestions",
+  "workflow consistency check", "find takt issues",
+  "analyze logs", "execution log diagnostics", "check takt logs", "rule evaluation statistics",
+  "ai_fallback frequency", "loop detection"
 ---
 
 # TAKT Analyzer
 
-Analyzes existing TAKT pieces and facets, detecting issues and providing improvement suggestions.
+Analyzes existing TAKT workflows and facets, detecting issues and providing improvement suggestions.
+
+> **Required takt version**: v0.35.4
 
 ## Reference Materials
 
 | Material | Path | Purpose |
 |----------|------|---------|
-| YAML Schema | `references/takt/builtins/skill/references/yaml-schema.md` | Piece structure validation criteria |
+| YAML Schema | `references/takt/builtins/skill/references/yaml-schema.md` | Workflow structure validation criteria |
 | Engine Specification | `references/takt/builtins/skill/references/engine.md` | Rule evaluation and execution specification |
 | Style Guides | `references/takt/builtins/en/*_STYLE_GUIDE.md` | Facet quality criteria |
-| Builtin Pieces | `references/takt/builtins/en/pieces/` | Structural pattern reference |
+| Builtin Workflows | `references/takt/builtins/en/workflows/` | Structural pattern reference |
 | Builtin Facets | `references/takt/builtins/en/{personas,policies,instructions,knowledge,output-contracts}/` | Facet quality reference |
+| Log Type Definitions | `references/takt/src/core/logging/contracts.ts` | NDJSON record type reference (renamed `observability` -> `logging` in v0.30.0) |
+| Provider Events | `references/takt/src/core/logging/providerEventLogger.ts` | `*-provider-events.jsonl` structure |
+| Usage Events | `references/takt/src/core/logging/usageEventLogger.ts` | Usage event structure |
+| Rule Evaluation | `references/takt/src/core/piece/evaluation/RuleEvaluator.ts` | matchedRuleMethod internals |
+
+## Difference from takt-optimize
+
+| Aspect | takt-analyze | takt-optimize |
+|--------|-------------|---------------|
+| Purpose | Issue detection, diagnostics, and reporting | Optimization execution |
+| Output | Analysis report (Markdown) | Optimized file set |
+| Changes | None (read-only) | Directly edits/generates files |
+| Input | Workflow YAML + facets + **execution logs** | Same |
+| Judgment | Severity classification of issues | Cost/quality tradeoff decisions |
 
 ## Analysis Categories
 
-### 1. Piece Structure Analysis
+### 1. Workflow Structure Analysis
 
-Detects structural issues in piece YAML.
+Detects structural issues in workflow YAML.
 
 **Checklist:**
 
 | Check | Description | Severity |
 |-------|-------------|----------|
-| initial_movement exists | Does `initial_movement` exist within the `movements` array? | Critical |
-| Transition target validity | Are all `rules.next` values valid movement names or `COMPLETE`/`ABORT`? | Critical |
-| Section map consistency | Do section map keys match references within movements? | Critical |
+| initial_step exists | Does `initial_step` exist within the `steps` array? | Critical |
+| Transition target validity | Are all `rules.next` values valid step names or `COMPLETE`/`ABORT`? | Critical |
+| loop healthy transition consistency | Does `loop_monitors.cycle`'s healthy `next` match the cycle head node? | Critical |
+| loop report range reference | Does `loop_monitors.judge.instruction`'s `{report:...}` reference only cycle-internal step outputs? | Critical |
+| Section map consistency | Do section map keys match references within steps? | Critical |
 | File path existence | Do paths in the section map actually exist? | Critical |
 | parallel structure | Does the parent rule use `all()`/`any()`, and do sub-steps lack `next`? | Warning |
-| edit permission | Do movements with `edit: true` have an appropriate `required_permission_mode`? | Info |
-| session setting | Do implementation movements have `session: refresh`? | Info |
+| edit=false + build operations | Does the instruction for an `edit: false` step explicitly prohibit build commands (`cargo check`, etc.)? Builds fail with `Operation not permitted` in a read-only sandbox | Warning |
+| supervise failure transition target | Does a `supervise` failure rule transition to `plan`? Fixable issues should transition to `fix`; `supervise -> plan` is only for cases requiring fundamental design changes | Warning |
+| CI execution responsibility placement | Do instructions for `edit: false` steps (`supervise`/`ai_review`, etc.) prohibit direct CI execution and only require verifying `fix`/`implement` report evidence? | Warning |
+| provider_options structure | Is `allowed_tools` placed under `provider_options.claude.allowed_tools` rather than top-level? (v0.30.0+) | Warning |
+| edit permission | Do steps with `edit: true` have an appropriate `required_permission_mode`? | Info |
+| session setting | Do implementation steps have `session: refresh`? | Info |
 
 ### 2. Facet Quality Analysis
 
@@ -50,7 +76,7 @@ Verifies that each facet complies with the style guide.
 - [ ] Role definition is 1-2 sentences
 - [ ] "Do" and "Don't" sections include the assigned agent name
 - [ ] No detailed policy rules (code examples, tables) mixed in
-- [ ] No piece-specific concepts (movement names, etc.)
+- [ ] No workflow-specific concepts (step names, etc.)
 - [ ] Size: simple 100 lines max, expert 550 lines max
 - [ ] No nesting below `####`
 
@@ -79,7 +105,7 @@ Detects whether responsibilities are properly separated across facets.
 | Violation Pattern | Description | Correction |
 |-------------------|-------------|------------|
 | Policy details in Persona | Rules with code examples or tables inside a Persona | -> Move to Policy |
-| Piece concepts in Persona | Movement names or report file names inside a Persona | -> Move to Instruction |
+| Workflow concepts in Persona | Step names or report file names inside a Persona | -> Move to Instruction |
 | Agent-specific knowledge in Policy | Detection techniques specific to a particular agent inside a Policy | -> Move to Persona domain knowledge |
 | Principles in Instruction | Shared coding principles inside an Instruction | -> Move to Policy |
 | Procedures in Output Contract | Execution steps inside an Output Contract | -> Move to Instruction |
@@ -94,6 +120,8 @@ Evaluates the design of rule conditions.
 | aggregate usage | Are `all()`/`any()` used in parallel parent rules? |
 | Unreachable rules | Are there cases that match no condition? |
 | Loop risk | Do cycles like fix->review have `loop_monitors`? |
+| loop healthy transition | Does each loop monitor's "healthy (progress made)" `next` point to the cycle head node? |
+| loop report consistency | Does a loop monitor reference reports exclusive to steps outside its cycle? |
 | ABORT conditions | Are ABORT transitions properly defined for failure cases? |
 
 ### 5. Builtin Utilization Analysis
@@ -105,31 +133,139 @@ Detects whether custom facets can be replaced with builtins.
 2. Suggest replacement with builtins when similarity is high
 3. Detect mixing of builtin bare name references and section map references
 
+### 6. Log-Based Diagnostic Analysis
+
+Parses execution logs (`.takt/logs/*.jsonl`) and detects dynamic issues. Skipped if no logs exist.
+
+#### a) Log Location and Format
+
+- `.takt/logs/{sessionId}.jsonl` (NDJSON format: one JSON object per line)
+- `.takt/logs/{sessionId}-provider-events.jsonl` (provider event log, separate file)
+- `.takt/logs/{sessionId}/trace.md` (trace report, Markdown format)
+- `.takt/logs/latest.json` to reference the latest session ID
+
+**NDJSON Record Types:**
+
+| type | Description |
+|------|-------------|
+| `piece_start` | Start of workflow execution |
+| `step_start` | Start of a step |
+| `step_complete` | Step completion (includes `matchedRuleIndex`, `matchedRuleMethod`) |
+| `phase_start` | Start of a phase |
+| `phase_complete` | Phase completion (has `error` field) |
+| `piece_complete` | Normal completion of workflow execution (includes `iterations`) |
+| `piece_abort` | Abort of workflow execution (includes `reason`) |
+| `interactive_start` / `interactive_end` | Start/end of interactive mode |
+
+> See `references/takt/src/shared/utils/types.ts` for detailed fields of each record type.
+
+#### b) matchedRuleMethod
+
+The `matchedRuleMethod` in `step_complete` records indicates which method the rule evaluation engine used to match the rule.
+
+**Evaluation Order (Fallback Chain):**
+
+```
+1. aggregate     -> all()/any() aggregation of parallel sub-steps
+2. phase3_tag    -> Tag detection from Phase 3 output
+3. phase1_tag    -> Tag detection from Phase 1 output (fallback)
+4. ai_judge      -> AI judgment of ai() conditions only
+5. ai_judge_fallback -> AI judgment of all conditions (final fallback)
+```
+
+**Method Characteristics:**
+
+| method | Cost | Reliability | Description |
+|--------|------|-------------|-------------|
+| `aggregate` | None | High | Determined by parallel sub-step completion status |
+| `phase3_tag` | None | High | Deterministic judgment by output template tags |
+| `phase1_tag` | None | Medium | Tag detection from agent response |
+| `ai_judge` | 1 API call | Medium | AI judgment of `ai()` conditions only |
+| `ai_judge_fallback` | 1 API call | Low | AI judgment of all conditions (when tag detection fails) |
+| `auto_select` | None | High | Automatic selection when only one rule exists |
+| `structured_output` | None | High | Judgment via structured output |
+
+> If `ai_judge_fallback` frequency is high, add tag output instructions to the output-contract.
+
+#### c) Diagnostic Analysis Items
+
+| Analysis | Method | Severity Criteria |
+|----------|--------|-------------------|
+| Loop hotspots | Count `step_start` occurrences for the same step | Exceeds threshold=Warning, no `loop_monitor`=Critical |
+| Dead rules | Detect rules with 0 matches from `matchedRuleIndex` distribution | Critical (unreachable code) |
+| Rule evaluation efficiency | Aggregate `matchedRuleMethod` distribution; focus on `ai_judge_fallback` proportion | >50%=Warning, >80%=Critical |
+| ABORT rate | Ratio of `piece_abort` / `piece_complete` | >30%=Warning, >50%=Critical |
+| Per-phase errors | Aggregate `phase_complete` `error` fields | Repeated errors in same phase=Warning |
+| Iteration efficiency | `piece_complete.iterations` vs `max_steps` | Consistently near limit=Warning |
+
+#### d) Multiple Log Integration Analysis Guide
+
+- **3+ runs**: Sufficient for pattern confirmation. Report statistical trends
+- **1 run**: Treat as reference information; prioritize static analysis
+
+#### e) Log Diagnostic Report Example
+
+```markdown
+## Log Diagnostic Results
+
+### Analysis Targets
+- Sessions: 5
+- Period: 2026-03-01 - 2026-03-04
+
+### Rule Evaluation Efficiency
+| Step | phase3_tag | ai_judge | ai_judge_fallback | Improvement Priority |
+|------|-----------|---------|-------------------|---------------------|
+| ai_review  | 20%       | 13%     | 67%               | High       |
+| supervise  | 80%       | 20%     | 0%                | -        |
+
+### Loop Hotspots
+| Cycle | Max Consecutive Count | loop_monitor | Status |
+|-------|----------------------|-------------|--------|
+| review->fix | 6 | threshold: 3 | OK |
+| implement->test | 4 | None | Warning: loop_monitor not set |
+
+### ABORT Analysis
+- Success: 4/5 (80%)
+- ABORT: 1/5 (20%) - reason: "max_steps exceeded"
+```
+
 ## Workflow
 
 ### Step 1: Identify Targets
 
-Identify the piece YAML to analyze.
+Identify the workflow YAML to analyze and check for the presence of execution logs.
 
 ```
 Search order:
 1. User-specified path
-2. Custom pieces in ~/.takt/pieces/
-3. Project pieces in .takt/pieces/
+2. Custom workflows in ~/.takt/workflows/
+3. Project workflows in .takt/workflows/
+
+Log check:
+- Check for the existence of the .takt/logs/ directory
+- Logs present -> Static analysis + log diagnostics
+- No logs -> Static analysis only (as before)
 ```
 
-### Step 2: Parse Piece YAML
+### Step 2: Parse Workflow YAML
 
-Load the piece YAML and perform structural analysis.
+Load the workflow YAML and perform structural analysis.
 
 1. Validate YAML syntax
-2. Verify movement composition
+2. Verify step composition
 3. Type-check rule conditions
 4. Resolve section map references
 
 ### Step 3: Load Facets and Quality Check
 
 Load all facets from the section map and builtin references, then verify against the style guides.
+
+### Step 3.5: Log Loading and Diagnostics (only when logs exist)
+
+1. Retrieve the latest session ID from `.takt/logs/latest.json`
+2. Load the target `.jsonl` file and parse NDJSON records
+3. Calculate each metric according to the Category 6 diagnostic analysis items
+4. If multiple logs exist, perform integrated analysis
 
 ### Step 4: Separation Analysis
 
@@ -138,7 +274,7 @@ Detect responsibility violations across facets.
 ### Step 5: Report Output
 
 ```markdown
-# TAKT Analysis Report: {piece name}
+# TAKT Analysis Report: {workflow name}
 
 ## Summary
 - Critical: {N issues}
@@ -159,4 +295,7 @@ Detect responsibility violations across facets.
 
 ## Builtin Utilization Suggestions
 {Proposals for replacing custom facets with builtins}
+
+## Log Diagnostic Results (only when logs are provided)
+{Log-based diagnostic summary}
 ```

--- a/plugins/takt/skills/takt-facet-builder/SKILL.en.md
+++ b/plugins/takt/skills/takt-facet-builder/SKILL.en.md
@@ -15,6 +15,8 @@ description: >
 
 Create and edit the 5 types of TAKT facet files individually.
 
+> **Required takt version**: v0.35.4
+
 ## Reference Materials
 
 When creating facets, refer to the materials in `references/takt/builtins/en/`.
@@ -27,8 +29,9 @@ When creating facets, refer to the materials in `references/takt/builtins/en/`.
 | Instruction Guide | `references/takt/builtins/en/INSTRUCTION_STYLE_GUIDE.md` | Instruction writing conventions |
 | Output Contract Guide | `references/takt/builtins/en/OUTPUT_CONTRACT_STYLE_GUIDE.md` | Output contract writing conventions |
 | Faceted Prompting | `references/takt/docs/faceted-prompting.en.md` | Theory of the 5-facet design |
-| Templates | `references/takt/builtins/en/templates/` | Templates for each facet |
-| Built-in Facets | `references/takt/builtins/en/{personas,policies,instructions,knowledge,output-contracts}/` | Existing facet examples |
+| Built-in Facets | `references/takt/builtins/en/facets/{personas,policies,instructions,knowledge,output-contracts}/` | Existing facet examples |
+
+**Note**: The templates directory has been removed. When creating new facets, refer to existing built-in facets instead.
 
 **Important**: Always read the relevant style guide before creating a facet.
 
@@ -42,7 +45,7 @@ Determine the facet type to create based on the user's requirements.
 This content is...
 ├── Identity/expertise specific to a particular agent → Persona
 ├── Behavioral norms shared across multiple agents → Policy
-├── Execution steps specific to a movement → Instruction
+├── Execution steps specific to a step → Instruction
 ├── Reference information that serves as a basis for decisions → Knowledge
 └── Structure definition for agent output → Output Contract
 ```
@@ -51,7 +54,7 @@ This content is...
 |-------|-----------|-------|--------------|
 | Persona | system prompt | 1 agent | "Is this knowledge specific to this agent?" |
 | Policy | within user message | Multiple agents | "Do multiple agents follow the same rule?" |
-| Instruction | Phase 1 message | 1 movement | "Is this procedure specific to this movement?" |
+| Instruction | Phase 1 message | 1 step | "Is this procedure specific to this step?" |
 | Knowledge | within user message | 1+ agents | "Is this reference information that serves as a basis for decisions?" |
 | Output Contract | Phase 2 message | 1 report | "Will downstream reference this via `{report:filename}`?" |
 
@@ -61,11 +64,11 @@ Check existing built-in facets of the same type and determine if they can be reu
 
 | Facet | Built-in Examples |
 |-------|-------------------|
-| Persona | coder, planner, architecture-reviewer, qa-reviewer, supervisor, security-reviewer |
-| Policy | coding, review, testing, qa, ai-antipattern |
-| Instruction | plan, implement, review-arch, review-qa, supervise, fix |
-| Knowledge | architecture, backend, cqrs-es, frontend, security |
-| Output Contract | plan, architecture-review, ai-review, summary, validation |
+| Persona | coder, planner, architect-planner, architecture-reviewer, qa-reviewer, supervisor, security-reviewer, frontend-reviewer, cqrs-es-reviewer, requirements-reviewer, testing-reviewer, terraform-reviewer, dual-supervisor, research-analyzer, research-digger, research-planner, research-supervisor, conductor, test-planner, ai-antipattern-reviewer |
+| Policy | coding, review, testing, qa, ai-antipattern, design-fidelity, design-planning, task-decomposition |
+| Instruction | plan, implement, implement-after-tests, write-tests-first, team-leader-implement, dual-team-leader-implement, review-arch, review-qa, review-security, review-frontend, review-cqrs-es, review-requirements, review-test, review-terraform, supervise, fix, ai-review, ai-fix, loop-monitor-ai-fix, loop-monitor-reviewers-fix, architecture-audit-plan, architecture-audit-review, architecture-audit-supervise, architecture-audit-team-leader, audit-security-plan, audit-security-review, audit-security-supervise, audit-security-team-leader, e2e-audit-plan, e2e-audit-review, e2e-audit-supervise, e2e-audit-team-leader, e2e-coverage-implement, e2e-coverage-plan, e2e-coverage-supervise, gather-review, unit-audit-plan, unit-audit-review, unit-audit-supervise, unit-audit-team-leader |
+| Knowledge | architecture, backend, cqrs-es, frontend, security, task-decomposition, takt, terraform-aws, e2e-testing, react, unit-testing |
+| Output Contract | plan, architecture-review, ai-review, qa-review, security-review, frontend-review, cqrs-es-review, requirements-review, testing-review, terraform-review, summary, validation, architecture-audit-plan, architecture-audit, audit-security, e2e-audit-plan, e2e-audit, e2e-coverage-plan, plan-frontend, test-report, unit-audit-plan, unit-audit, supervisor-validation |
 
 **Reuse Decision**: Do not create a custom facet if a built-in is sufficient.
 
@@ -73,7 +76,7 @@ Check existing built-in facets of the same type and determine if they can be reu
 
 #### Persona
 
-Templates: `templates/personas/{simple,expert,character}.md`
+Reference: existing facets in `references/takt/builtins/en/facets/personas/`
 
 | Template | Use Case | Examples |
 |----------|----------|----------|
@@ -108,13 +111,13 @@ Templates: `templates/personas/{simple,expert,character}.md`
 
 **Prohibited**:
 - Copying detailed policy rules (code examples, tables) (a one-line behavioral guideline is OK)
-- Piece-specific concepts (movement names, report file names)
+- Workflow-specific concepts (step names, report file names)
 - Tool-specific paths (`.takt/runs/`, etc.)
 - Execution steps
 
 #### Policy
 
-Template: `templates/policies/policy.md`
+Reference: existing facets in `references/takt/builtins/en/facets/policies/`
 
 ```markdown
 # {Policy Name}
@@ -136,12 +139,12 @@ Template: `templates/policies/policy.md`
 
 **Prohibited**:
 - Knowledge specific to a particular agent
-- Piece-specific concepts, tool-specific paths
+- Workflow-specific concepts, tool-specific paths
 - Execution steps
 
 #### Instruction
 
-Templates: `templates/instructions/{plan,implement,review,fix,supervise,...}.md`
+Reference: existing facets in `references/takt/builtins/en/facets/instructions/`
 
 ```markdown
 {Purpose statement. 1-2 lines, imperative mood}
@@ -166,15 +169,15 @@ Templates: `templates/instructions/{plan,implement,review,fix,supervise,...}.md`
 - Persona content (expertise, behavioral stance)
 - Policy content (shared coding principles)
 - Manual description of auto-injected variables (`{task}`, `{previous_response}`)
-- Direct references to other movement names
+- Direct references to other step names
 
 **Template Variables** (available for use):
-- `{iteration}`, `{max_movements}`, `{movement_iteration}`
+- `{iteration}`, `{max_steps}`, `{step_iteration}`
 - `{report_dir}`, `{report:filename}`, `{cycle_count}`
 
 #### Knowledge
 
-Template: `templates/knowledge/knowledge.md`
+Reference: existing facets in `references/takt/builtins/en/facets/knowledge/`
 
 ```markdown
 # {Domain Name} Knowledge
@@ -205,7 +208,7 @@ Verification approach:
 
 #### Output Contract
 
-Templates: `templates/reports/{plan,review,validation,summary,...}.md`
+Reference: existing facets in `references/takt/builtins/en/facets/output-contracts/`
 
 ````markdown
 ```markdown
@@ -229,6 +232,10 @@ Templates: `templates/reports/{plan,review,validation,summary,...}.md`
 **Size Guidelines**: 10-25 lines (max 30 lines, excluding cognitive load reduction rules)
 
 **Status Patterns**: `APPROVE / REJECT` (binary), `APPROVE / IMPROVE / REJECT` (ternary), `Complete` (fixed value)
+
+**Review Output Contract Structure** (v0.30.0+):
+- Add a `family_tag` column to each finding (category classification of findings)
+- Section structure: `new` (new) -> `persists` (persists) -> `resolved` (resolved) -> `reopened` (reopened)
 
 **Prohibited**:
 - Execution steps (responsibility of Instructions)
@@ -259,7 +266,7 @@ Verify the quality of the created facet.
 - [ ] Role definition is 1-2 sentences
 - [ ] "Do" and "Do not" sections include responsible agent names
 - [ ] No detailed policy rules have leaked in
-- [ ] No piece-specific concepts
+- [ ] No workflow-specific concepts
 
 **Policy:**
 - [ ] Purpose statement is one sentence
@@ -279,3 +286,17 @@ Verify the quality of the created facet.
 - [ ] Wrapped in a ```markdown code block
 - [ ] Review types have status and cognitive load reduction rules
 - [ ] No numeric prefix in file name
+
+## Validation
+
+Created/edited files can be mechanically verified with `validate-takt-files.sh`:
+
+```bash
+bash .agents/skills/takt-facet/scripts/validate-takt-files.sh
+```
+
+Verification items:
+- **Workflow YAML**: Required fields (`name`/`initial_step`/`steps`), `initial_step` step references, facet file reference existence
+- **Facet .md**: Empty check, persona/policy/knowledge require `# heading`, instruction/output-contract require content existence
+
+Options `--workflows` / `--facets` can be used to narrow the scope.

--- a/plugins/takt/skills/takt-optimizer/SKILL.en.md
+++ b/plugins/takt/skills/takt-optimizer/SKILL.en.md
@@ -1,45 +1,47 @@
 ---
 name: takt-optimizer
 description: >
-  A skill for optimizing existing TAKT workflows (piece YAMLs and facets).
-  Performs token consumption reduction, movement consolidation, rule simplification,
+  A skill for optimizing existing TAKT workflows (workflow YAMLs and facets).
+  Performs token consumption reduction, step consolidation, rule simplification,
   facet reuse promotion, loop control improvement, and parallelization proposals,
   then directly generates the optimized files.
-  When execution logs (.takt/logs/*.jsonl) are provided, it also performs
-  optimizations based on real data such as rule match distribution, loop frequency,
-  and ABORT rates.
-  While takt-analyze specializes in "analysis and reporting", this skill specializes
-  in "executing optimizations".
+  Can utilize takt-analyze diagnostic results (static analysis and log diagnostics) as input.
+  This skill handles only "executing optimizations"; diagnostics and analysis are delegated to takt-analyze.
   Uses references/takt engine specifications and style guides as the baseline.
-  Triggers: "optimize pieces", "speed up takt", "make the workflow lighter",
-  "reduce tokens", "reduce movements", "takt optimize",
-  "streamline the workflow", "clean up facets", "slim down the piece",
-  "reduce takt costs", "simplify the workflow",
-  "optimize from logs", "analyze execution logs and optimize", "improve takt from logs"
+  Triggers: "optimize workflows", "speed up takt", "make the workflow lighter",
+  "reduce tokens", "reduce steps", "takt optimize",
+  "streamline the workflow", "clean up facets", "slim down the workflow",
+  "reduce takt costs", "simplify the workflow"
 ---
 
 # TAKT Optimizer
 
-Analyzes existing TAKT workflows and executes optimizations.
+Executes optimizations on existing TAKT workflows. Diagnostics and analysis are handled by takt-analyze.
+
+> **Required takt version**: v0.35.4
 
 ## Reference Materials
 
 | Material | Path | Purpose |
 |----------|------|---------|
-| YAML Schema | `references/takt/builtins/skill/references/yaml-schema.md` | Piece structure validation baseline |
+| YAML Schema | `references/takt/builtins/skill/references/yaml-schema.md` | Workflow structure validation baseline |
 | Engine Specification | `references/takt/builtins/skill/references/engine.md` | Understanding prompt construction and token consumption |
 | Style Guides | `references/takt/builtins/en/*_STYLE_GUIDE.md` | Facet size limits |
-| Built-in Pieces | `references/takt/builtins/en/pieces/` | Optimization pattern reference |
+| Built-in Workflows | `references/takt/builtins/en/workflows/` | Optimization pattern reference |
 | Built-in Facets | `references/takt/builtins/en/{personas,policies,instructions,knowledge,output-contracts}/` | Built-in replacement candidates |
 
 ## Difference from takt-analyze
 
 | Aspect | takt-analyze | takt-optimize |
 |--------|-------------|---------------|
-| Purpose | Problem detection and reporting | Executing optimizations |
+| Purpose | Problem detection, diagnostics and reporting | Executing optimizations |
 | Output | Analysis report (Markdown) | Optimized file set |
 | Modifications | None (read-only) | Directly edits/generates files |
+| Input | Workflow YAML + facets + execution logs | Workflow YAML + facets + **takt-analyze diagnostic results** |
 | Judgment | Severity classification of issues | Cost/quality tradeoff decisions |
+| Log analysis | Performs analysis and generates diagnostic reports | Utilizes takt-analyze diagnostic results |
+
+> **Recommended flow**: `takt-analyze` (diagnostics) -> Use those results for `takt-optimize` (execute optimizations)
 
 ## Optimization Categories
 
@@ -57,9 +59,9 @@ Persona -> Policy -> Context -> Knowledge -> Instruction
 
 | Optimization | Method | Effect |
 |-------------|--------|--------|
-| Persona compression | Remove redundant descriptions, compress within size limits | Reduction at each movement |
-| Policy splitting | Split large policies by purpose, assign only to relevant movements | 2x effect (includes reminder portion) |
-| Knowledge scoping | Remove unnecessary knowledge references from movements | Reduce unnecessary context |
+| Persona compression | Remove redundant descriptions, compress within size limits | Reduction at each step |
+| Policy splitting | Split large policies by purpose, assign only to relevant steps | 2x effect (includes reminder portion) |
+| Knowledge scoping | Remove unnecessary knowledge references from steps | Reduce unnecessary context |
 | Instruction simplification | Remove manual descriptions of auto-injected content | Eliminate duplication |
 | Output contract slimming | Compress output contracts exceeding 30 lines | Reduction in report directive portion |
 
@@ -75,18 +77,18 @@ Persona -> Policy -> Context -> Knowledge -> Instruction
 | Instruction (implement) | 30-50 lines | - |
 | Output Contract | 10-25 lines | 30 lines |
 
-### 2. Movement Consolidation
+### 2. Step Consolidation
 
-Consolidate unnecessary movements to reduce the total number of steps in the workflow.
+Consolidate unnecessary steps to reduce the total number of steps in the workflow.
 
 | Pattern | Detection Condition | Optimization |
 |---------|-------------------|-------------|
-| Consecutive same persona | Adjacent movements share the same persona | Consolidate into 1 movement |
-| Single-rule transition | Only 1 rule with unconditional transition | Consider consolidating with adjacent movements |
-| edit=false chain | Chain of read-only movements | Evaluate consolidation potential |
+| Consecutive same persona | Adjacent steps share the same persona | Consolidate into 1 step |
+| Single-rule transition | Only 1 rule with unconditional transition | Consider consolidating with adjacent steps |
+| edit=false chain | Chain of read-only steps | Evaluate consolidation potential |
 
 **Consolidation criteria:**
-- Whether the persona is the same or different between movements
+- Whether the persona is the same or different between steps
 - Whether it breaks session: refresh boundaries
 - Whether independent report output is required
 - Whether rule branching is substantively meaningful
@@ -120,12 +122,12 @@ Replace custom facets with built-ins and reduce section maps.
 # Before: Custom facet referenced in section map
 personas:
   my-coder: ../personas/my-coder.md
-movements:
+steps:
   - name: implement
     persona: my-coder
 
 # After: Built-in bare name reference
-movements:
+steps:
   - name: implement
     persona: coder    # Direct built-in reference
 ```
@@ -144,19 +146,24 @@ Improve efficiency and safety of fix loops.
 | Add loop_monitors | Add loop_monitor when review-fix cycles lack one |
 | Threshold adjustment | Propose appropriate values when thresholds are too high/low |
 | Add ABORT conditions | Add ABORT transitions when missing for failure cases |
-| max_movements adjustment | Adjust when max_movements is excessive/insufficient for the number of movements |
+| max_steps adjustment | Adjust when max_steps is excessive/insufficient for the number of steps |
+| Fix supervise failure transition | Change `supervise` failure rule to transition to `fix` instead of `plan`. The `supervise -> plan` loop tends to be high-cost and unproductive |
+| Add edit=false build prohibition | Add a prohibition section ("## Do Not") to instructions referenced by `edit: false` steps stating "Do not execute build commands" |
+| Normalize loop monitor judge instruction | Unify `loop_monitors.judge.instruction` to built-in facet references (`loop-monitor-ai-fix`, `loop-monitor-reviewers-fix`) and remove legacy judge template notation |
+| Migrate allowed_tools to provider_options | Move top-level `allowed_tools` to `provider_options.claude.allowed_tools` (v0.30.0+) |
 
 **Recommended threshold values:**
 - review-fix cycle: 3 times
+- supervise-fix cycle: 3 times
 - implement-test cycle: 2 times
 
 ### 6. Parallelization Proposals
 
-Detect movements executed sequentially that could be parallelized.
+Detect steps executed sequentially that could be parallelized.
 
 **Parallelization conditions:**
 - Do not reference each other's output (pass_previous_response not needed)
-- Take the same preceding movement's report as input
+- Take the same preceding step's report as input
 - Produce independent reports
 
 ```yaml
@@ -189,98 +196,56 @@ Detect movements executed sequentially that could be parallelized.
       next: fix
 ```
 
-### 7. Log-Based Optimization
+### 7. Optimization Based on Log Diagnostic Results
 
-Analyze execution logs (`.takt/logs/{sessionId}.jsonl`) and perform optimizations based on real data.
+Use takt-analyze log diagnostic results as input to execute optimizations based on real data.
 
-**Log locations:**
-- Session logs: `.takt/logs/{sessionId}.jsonl` (NDJSON format)
-- Latest session: Accessible via `.takt/logs/latest.json`
+> **Prerequisite**: Log reading, parsing, and diagnostics are handled by takt-analyze. This category only covers "what to change" based on the diagnostic results.
 
-**NDJSON record types:**
+**Diagnostic results -> Optimization actions:**
 
-| Record | Key Fields | Use for Optimization |
-|--------|-----------|---------------------|
-| `piece_start` | `task`, `pieceName`, `startTime` | Identify execution patterns |
-| `step_start` | `step`, `persona`, `iteration` | Movement execution frequency |
-| `step_complete` | `step`, `status`, `matchedRuleIndex`, `matchedRuleMethod` | Rule match analysis |
-| `phase_start` | `step`, `phase`(1/2/3), `phaseName` | Phase-level analysis |
-| `phase_complete` | `step`, `phase`, `status`, `content`, `error` | Phase-level bottlenecks |
-| `piece_complete` | `iterations`, `endTime` | Total iteration count |
-| `piece_abort` | `iterations`, `reason`, `endTime` | Failure pattern analysis |
-
-**Analysis items and optimizations:**
-
-| Analysis | Method | Optimization Action |
-|----------|--------|-------------------|
-| Loop hotspots | Count occurrences of `step_start` for the same step | Adjust loop_monitor threshold, review rule conditions |
-| Dead rule detection | Aggregate `matchedRuleIndex` distribution, identify never-matched rules | Remove unreachable rules |
-| ai_fallback frequency | Ratio of `matchedRuleMethod` being `ai_judge_fallback` | Rewrite to tag-based rules (cost reduction and reliability improvement) |
-| ABORT rate | Ratio of `piece_abort` to `piece_complete` | Analyze ABORT `reason` and improve flow |
-| Phase-level errors | `error` field in `phase_complete` | Identify and improve error-prone phases |
-| Iteration efficiency | `piece_complete.iterations` vs `max_movements` | Calculate appropriate max_movements value |
-
-**matchedRuleMethod values and meanings:**
-
-| Value | Meaning | Optimization Perspective |
-|-------|---------|------------------------|
-| `phase3_tag` | Determined by Phase 3 tag judgment | Ideal (low cost) |
-| `phase1_tag` | Determined by Phase 1 output tag | Good (Phase 3 may be unnecessary) |
-| `aggregate` | Determined by parallel parent's all()/any() | Normal |
-| `ai_judge` | Determined by AI judgment of ai() condition | Acceptable (consider tag conversion) |
-| `ai_judge_fallback` | All conditions judged by AI (last resort) | Needs improvement (tags not being output) |
-| `auto_select` | Automatic selection | Normal |
-
-**Log analysis example:**
-
-```
-# Results from analyzing 3 execution logs:
-Step "ai_review" matchedRuleMethod distribution:
-  phase3_tag: 1 time (33%)
-  ai_judge_fallback: 2 times (67%)
--> Proposal: Status tags are not being output consistently.
-  Strengthen tag output directives in instructions, or simplify rule condition text.
-```
-
-**Multi-log integrated analysis:**
-
-When multiple session logs are provided, propose statistically reliable optimizations.
-- 3+ execution runs: Sufficient to confirm patterns
-- 1 execution run: Treat as reference data, prioritize static analysis
+| takt-analyze Diagnostic | Optimization Action |
+|------------------------|-------------------|
+| Loop hotspot (Warning/Critical) | Adjust `loop_monitor` `threshold`, review rule conditions |
+| Dead rule (Critical) | Remove unreachable rules |
+| Low rule evaluation efficiency (`ai_judge_fallback` high frequency) | Rewrite to tag-based rules, add tag output directives to output-contract |
+| High ABORT rate | Improve flow based on ABORT `reason` (`max_steps` adjustment, add ABORT conditions) |
+| Repeated phase-level errors | Improve instructions and personas for error-prone phases |
+| Low iteration efficiency | Calculate appropriate `max_steps` value, consider step consolidation |
 
 ## Workflow
 
 ### Step 1: Identify and Load Targets
 
-Identify the target piece YAML and load all related facets.
+Identify the target workflow YAML and load all related facets.
 
 ```
 Search order:
 1. User-specified path
-2. Custom pieces in ~/.takt/pieces/
-3. Project pieces in .takt/pieces/
+2. Custom workflows in ~/.takt/workflows/
+3. Project workflows in .takt/workflows/
 ```
 
 Content to load:
-- Entire piece YAML
+- Entire workflow YAML
 - All facet files from the section map
 - Built-in facets (for comparison)
-- Execution logs (if provided by user): `.takt/logs/*.jsonl`
+- takt-analyze diagnostic report (if provided)
 
 ### Step 2: Create Optimization Plan
 
 Evaluate the optimization potential of each category and present a plan.
 
 ```markdown
-# Optimization Plan: {piece name}
+# Optimization Plan: {workflow name}
 
 ## Analysis Sources
-- Static analysis: Piece YAML + {N} facets
-- Log analysis: {N} sessions (if provided)
+- Static analysis: Workflow YAML + {N} facets
+- takt-analyze diagnostics: {summary of diagnostic report} (if provided)
 
 ## Estimated Impact
 - Token reduction: ~{N}%
-- Movement count: {before} -> {after}
+- Step count: {before} -> {after}
 - File count: {before} -> {after}
 
 ## Optimization Items
@@ -288,7 +253,7 @@ Evaluate the optimization potential of each category and present a plan.
 |---|----------|--------|---------|-------|------|
 | 1 | Token reduction | persona/coder | Compress 120 lines -> 80 lines | Static | Low |
 | 2 | Built-in replacement | persona/my-reviewer | -> architecture-reviewer | Static | Low |
-| 3 | Rule simplification | ai_review | ai_fallback 67% -> tag conversion | Log | Low |
+| 3 | Rule simplification | ai_review | ai_fallback 67% -> tag conversion | Diagnostic | Low |
 | 4 | Parallelization | arch-review + qa-review | Sequential -> parallel | Static | Medium |
 ```
 
@@ -306,18 +271,18 @@ Execute the approved items.
 **Execution order (by dependency):**
 1. Facet compression/consolidation (file content changes)
 2. Built-in replacement (section map changes)
-3. Movement consolidation (YAML structure changes)
+3. Step consolidation (YAML structure changes)
 4. Rule simplification (rule condition changes)
 5. Loop control improvement (add loop_monitors)
-6. Parallelization (major movement structure changes)
+6. Parallelization (major step structure changes)
 
 ### Step 4: Consistency Verification
 
 Verify the consistency of optimized files.
 
-- [ ] Section map keys match references within movements
+- [ ] Section map keys match references within steps
 - [ ] Section map paths point to existing files
-- [ ] `initial_movement` exists within the `movements` array
+- [ ] `initial_step` exists within the `steps` array
 - [ ] All rule `next` values point to valid transition targets
 - [ ] Parallel parent rules use `all()`/`any()`
 - [ ] Parallel sub-step rules do not have `next`
@@ -327,17 +292,17 @@ Verify the consistency of optimized files.
 ### Step 5: Results Report
 
 ```markdown
-# Optimization Results: {piece name}
+# Optimization Results: {workflow name}
 
 ## Summary
 - Token reduction: ~{N}% (estimated)
-- Movement count: {before} -> {after}
+- Step count: {before} -> {after}
 - File count: {before} -> {after}
 
 ## Change List
 | # | File | Changes |
 |---|------|---------|
-| 1 | pieces/my-piece.yaml | Movement consolidation, rule simplification |
+| 1 | pieces/my-piece.yaml | Step consolidation, rule simplification |
 | 2 | personas/coder.md | Compressed 120 lines -> 80 lines |
 | 3 | (deleted) personas/my-reviewer.md | Replaced with built-in |
 
@@ -347,3 +312,17 @@ Verify the consistency of optimized files.
 ## Notes
 {Describe any potential behavioral changes due to optimization}
 ```
+
+## Validation
+
+Created/edited files can be mechanically verified with `validate-takt-files.sh`:
+
+```bash
+bash .agents/skills/takt-optimize/scripts/validate-takt-files.sh
+```
+
+Verification items:
+- **Workflow YAML**: Required fields (`name`/`initial_step`/`steps`), `initial_step` step reference, facet file reference existence
+- **Facet .md**: Empty check, persona/policy/knowledge require `# heading`, instruction/output-contract require content
+
+Options `--pieces` / `--facets` can narrow the targets.

--- a/plugins/takt/skills/takt-task-builder/SKILL.en.md
+++ b/plugins/takt/skills/takt-task-builder/SKILL.en.md
@@ -14,7 +14,7 @@ description: >
 
 Create and edit TAKT tasks.yaml entries and task directories (order.md).
 
-> **Required takt version**: v0.29.0
+> **Required takt version**: v0.35.4
 
 ## Reference Materials
 
@@ -22,11 +22,11 @@ Task-management materials are under `references/takt/`. Refer to the following a
 
 | Material | Path | Purpose |
 |----------|------|---------|
-| Task management docs | `references/takt/docs/task-management.md` | Overall task workflow |
+| Task management docs | `references/takt/docs/task-management.ja.md` | Overall task workflow |
 | TaskRecord schema | `references/takt/src/infra/task/schema.ts` | Field definitions and validation |
 | Task format spec | `references/takt/builtins/project/tasks/TASK-FORMAT` | Details of `task_dir` format |
 | Schema details | This skill's `references/task-schema.md` | Field list and status transitions |
-| Validation script | This skill's `scripts/validate-order-md.sh` | Structural validation for order.md |
+| Validation script | This skill's `validate-order-md.sh` | Structural validation for order.md |
 
 **Important**: TaskRecord status-transition rules are strictly validated. Read `references/task-schema.md` and understand the invariants.
 
@@ -37,7 +37,7 @@ Task-management materials are under `references/takt/`. Refer to the following a
 Confirm the following (ask the user if anything is unclear):
 
 1. **Task content**: What should this task execute?
-2. **Piece**: Piece name to use (`default`, `dual`, custom, etc.)
+2. **Workflow**: Workflow name to use (`default`, `dual`, custom, etc.)
 3. **Isolated execution**: Whether `worktree` is needed (`true` / path / omitted)
 4. **Branch**: Custom branch name (auto-generated if omitted)
 5. **Auto PR creation**: Whether `auto_pr` / `draft_pr` are needed
@@ -133,7 +133,7 @@ Cost to keep shared types/interfaces consistent across tasks. TAKT has no live s
 tasks:
   - name: impl-module-a
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260301-100000-aaaaaa
     worktree: true
     branch: feat/module-a
@@ -143,7 +143,7 @@ tasks:
     completed_at: null
   - name: impl-module-b
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260301-100000-bbbbbb
     worktree: true
     branch: feat/module-b
@@ -153,7 +153,7 @@ tasks:
     completed_at: null
   - name: impl-module-c
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260301-100000-cccccc
     worktree: true
     branch: feat/module-c
@@ -167,21 +167,7 @@ Run in parallel with `takt run --concurrency 3`.
 
 **Pattern B: Dependency merge (schema + implementation in one task)**
 
-```yaml
-tasks:
-  - name: add-user-profile
-    status: pending
-    piece: default
-    task_dir: .takt/tasks/20260301-100000-dddddd
-    worktree: true
-    branch: feat/user-profile
-    auto_pr: true
-    created_at: "2026-03-01T10:00:00.000Z"
-    started_at: null
-    completed_at: null
-```
-
-Describe both schema changes and implementation in `order.md`, then execute as one task.
+Merge dependent tasks into one. The tasks.yaml entry is the same as the minimal configuration in Step 4. Describe both schema changes and implementation in `order.md`, then execute as one task.
 
 **Pattern C: Phased execution (leading task -> merge -> following parallel tasks)**
 
@@ -191,7 +177,7 @@ Phase 1: Shared foundation
 tasks:
   - name: define-shared-types
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260301-100000-eeeeee
     worktree: true
     branch: feat/shared-types
@@ -207,7 +193,7 @@ Run with `takt run`, then after PR merge add phase-2 tasks:
 tasks:
   - name: impl-consumer-x
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260301-110000-ffffff
     worktree: true
     branch: feat/consumer-x
@@ -217,7 +203,7 @@ tasks:
     completed_at: null
   - name: impl-consumer-y
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260301-110000-gggggg
     worktree: true
     branch: feat/consumer-y
@@ -291,7 +277,7 @@ tasks: []
 tasks:
   - name: add-auth-feature
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260223-143000-ab12cd
     created_at: "2026-02-23T14:30:00.000Z"
     started_at: null
@@ -304,7 +290,7 @@ tasks:
 tasks:
   - name: add-auth-feature
     status: pending
-    piece: default
+    workflow: default
     task_dir: .takt/tasks/20260223-143000-ab12cd
     slug: 20260223-143000-ab12cd
     worktree: true
@@ -323,7 +309,7 @@ tasks:
 tasks:
   - name: fix-login-bug
     status: pending
-    piece: default
+    workflow: default
     content: >-
       Fix the authentication error on the login screen.
       Root cause: invalid session-token expiration check.
@@ -351,7 +337,7 @@ Verify consistency of the created tasks (see `references/task-schema.md` for det
 - [ ] With `status: pending`, `started_at: null` and `completed_at: null`
 - [ ] `created_at` is ISO8601 format
 - [ ] Exactly one of `content`, `content_file`, `task_dir` is specified
-- [ ] `piece` matches an existing piece (builtin or custom)
+- [ ] `workflow` matches an existing workflow (builtin or custom)
 - [ ] Overall `tasks.yaml` structure is not broken
 
 #### Parallel consistency checks (for multiple tasks)
@@ -363,10 +349,11 @@ Verify consistency of the created tasks (see `references/task-schema.md` for det
 
 #### `order.md` structural validation
 
-Run `validate-order-md.sh` for mechanical validation of `order.md` structure:
+Run the `scripts/validate-order-md.sh` bundled with this skill for mechanical validation of `order.md` structure.
+Execute using the path appropriate for the skill's deployment location (`.agents/skills/`, `.claude/skills/`, `.codex/skills/`, etc.):
 
 ```bash
-bash .agents/skills/takt-task/scripts/validate-order-md.sh
+bash <this skill's directory>/scripts/validate-order-md.sh
 ```
 
 Validation items:
@@ -376,17 +363,18 @@ Validation items:
 - Items in `## Acceptance Criteria` section (at least one)
 - Cross-check: `task_dir` in `tasks.yaml` -> existence of `order.md`
 
-#### Additional gate for piece changes (required)
+#### Additional gate for workflow changes (required)
 
-If this task edits `.takt/pieces/*.yaml`, run the following before completion judgment:
+If this task edits `.takt/workflows/*.yaml`, run the `takt-workflow-builder` skill's validation script before completion judgment.
+Execute using the path appropriate for the skill's deployment location:
 
 ```bash
-bash .agents/skills/takt-workflow-builder/scripts/validate-takt-files.sh --pieces
+bash <takt-workflow-builder skill directory>/scripts/validate-takt-files.sh --pieces
 ```
 
 Also confirm the following two points:
 - In healthy loop monitor state, `next` matches the head node of `cycle`
-- `{report:...}` references in loop monitor are limited to movement outputs generated inside the cycle
+- `{report:...}` references in loop monitor are limited to step outputs generated inside the cycle
 
 If either condition cannot be met, do not mark the task as `completed`.
 
@@ -397,7 +385,9 @@ If either condition cannot be met, do not mark the task as `completed`.
 | pending -> running | YES |
 | running -> completed | YES |
 | running -> failed | YES |
-| running -> exceeded | YES (when `max_movements` is exceeded) |
+| running -> exceeded | YES (when `max_steps` is exceeded) |
+| running -> pr_failed | YES (when PR creation fails) |
 | pending -> completed | NO (must pass through `running`) |
 | completed -> pending | NO (recreate as a new task) |
 | exceeded -> pending | NO (recreate as a new task) |
+| pr_failed -> pending | NO (recreate as a new task) |

--- a/plugins/takt/skills/takt-workflow-builder/SKILL.en.md
+++ b/plugins/takt/skills/takt-workflow-builder/SKILL.en.md
@@ -1,19 +1,21 @@
 ---
 name: takt-workflow-builder
 description: >
-  Skill for creating and customizing TAKT pieces (workflow YAML). Includes
+  Skill for creating and customizing TAKT workflows (workflow YAML). Includes
   generation of facet files based on Faceted Prompting
   (Persona/Policy/Instruction/Knowledge/Output Contract). Leverages TAKT
-  source code, documentation, and builtin pieces in references/takt as
-  reference materials. Gathers user requirements and performs movement
+  source code, documentation, and builtin workflows in references/takt as
+  reference materials. Gathers user requirements and performs step
   composition, rule design, and facet file generation all at once.
-  Triggers: "create a piece", "define a workflow", "create a takt piece",
-  "make a new takt piece", "takt piece", "workflow YAML"
+  Triggers: "create a workflow", "define a workflow", "create a takt workflow",
+  "make a new takt workflow", "takt workflow", "workflow YAML"
 ---
 
 # TAKT Piece Builder
 
-Creates TAKT pieces (workflow YAML) and their associated facet files.
+Creates TAKT workflows (workflow YAML) and their associated facet files.
+
+> **Target takt version**: v0.35.4
 
 ## Reference Materials
 
@@ -21,15 +23,15 @@ The TAKT codebase and documentation are located in `references/takt/`. Refer to 
 
 | Resource | Path | Purpose |
 |----------|------|---------|
-| YAML Schema | `references/takt/builtins/skill/references/yaml-schema.md` | Piece YAML structure definition |
+| YAML Schema | `references/takt/builtins/skill/references/yaml-schema.md` | Workflow YAML structure definition |
 | Engine Specification | `references/takt/builtins/skill/references/engine.md` | Details on prompt construction and rule evaluation |
 | Faceted Prompting | `references/takt/docs/faceted-prompting.en.md` | Theory of 5-facet design |
-| Builtin Pieces | `references/takt/builtins/en/pieces/` | Examples (default.yaml, expert.yaml, etc.) |
+| Builtin Workflows | `references/takt/builtins/en/workflows/` | Examples (default.yaml, dual.yaml, etc.) |
 | Style Guide | `references/takt/builtins/en/STYLE_GUIDE.md` | Facet writing conventions |
 | Persona Guide | `references/takt/builtins/en/PERSONA_STYLE_GUIDE.md` | Persona writing conventions |
-| Builtin Facets | `references/takt/builtins/en/{personas,policies,instructions,knowledge,output-contracts}/` | Existing facet examples |
+| Builtin Facets | `references/takt/builtins/en/facets/{personas,policies,instructions,knowledge,output-contracts}/` | Existing facet examples |
 
-**Important**: Before creating a piece, read `references/takt/builtins/en/pieces/default.yaml` to understand the project's patterns.
+**Important**: Before creating a workflow, read `references/takt/builtins/en/workflows/default.yaml` to understand the project's patterns.
 
 ## Workflow
 
@@ -37,34 +39,50 @@ The TAKT codebase and documentation are located in `references/takt/`. Refer to 
 
 Confirm the following (ask the user about any unclear points):
 
-1. **Objective**: What this piece should achieve
-2. **Movement composition**: What steps are needed (plan->implement->review->supervise, etc.)
+1. **Objective**: What this workflow should achieve
+2. **Step composition**: What steps are needed (plan->implement->review->supervise, etc.)
 3. **Review structure**: Whether parallel reviews are needed, types of reviewers
 4. **Loop control**: Whether fix loops are needed and their thresholds
-5. **Output location**: Where to place pieces and facets (default: `~/.takt/pieces/`)
+5. **Output location**: Where to place workflows and facets (default: `~/.takt/workflows/`)
 
 ### Step 2: Builtin Reference
 
-Search for similar patterns in builtin pieces (`references/takt/builtins/en/pieces/`).
+Search for similar patterns in builtin workflows (`references/takt/builtins/en/workflows/`).
 
 | Builtin | Composition | Purpose |
 |---------|-------------|---------|
-| `default.yaml` | plan->implement->ai_review->reviewers(arch+qa)->supervise | Standard development |
-| `expert.yaml` | plan->implement->ai_review->reviewers(arch+frontend+security+qa)->supervise | Full stack |
-| `default-mini.yaml` | plan->implement->supervise | Minimal configuration |
-| `review-only.yaml` | Review only | Code review only |
+| `default.yaml` | plan->write_tests->implement->ai_review->reviewers(arch+qa)->fix->supervise | Standard development |
+| `dual.yaml` | plan->write_tests->team_leader_implement->ai_review->reviewers(2-stage)->fix->supervise | Frontend + Backend |
+| `backend.yaml` | plan->write_tests->implement->ai_review->reviewers->fix->supervise | Backend-specific |
+| `backend-cqrs.yaml` / `backend-cqrs-mini.yaml` | CQRS+ES backend development | CQRS/ES-specific |
+| `frontend.yaml` | plan->write_tests->implement->ai_review->reviewers->fix->supervise | Frontend-specific |
+| `backend-mini.yaml` / `dual-mini.yaml` / `dual-cqrs-mini.yaml` / `frontend-mini.yaml` | plan->implement->supervise | Minimal configuration |
+| `review-default.yaml` / `review-backend.yaml` / `review-dual.yaml` / `review-frontend.yaml` | Review workflow | Code review |
+| `review-fix-default.yaml` / `review-fix-backend.yaml` / `review-fix-dual.yaml` / `review-fix-frontend.yaml` | Review->fix loop | Review + fix |
+| `takt-default.yaml` / `review-takt-default.yaml` / `review-fix-takt-default.yaml` | TAKT development | TAKT development |
+| `audit-architecture.yaml` / `audit-architecture-backend.yaml` / `audit-architecture-dual.yaml` / `audit-architecture-frontend.yaml` | Architecture audit | Quality audit |
+| `audit-e2e.yaml` / `audit-security.yaml` / `audit-unit.yaml` | E2E/Security/Unit test audit | Quality audit |
+| `terraform.yaml` | Infrastructure | Terraform |
+| `research.yaml` / `deep-research.yaml` | Research | Research |
+| `magi.yaml` / `compound-eye.yaml` | Special composition | Multi-perspective analysis |
 
 **Reuse decision**: Do not create custom facets if builtin facets are sufficient.
 
-### Step 3: Piece YAML Creation
+### Step 3: Workflow YAML Creation
 
 Create the YAML with the following structure.
 
 ```yaml
-name: piece-name
-description: Piece description
-max_movements: 30
-initial_movement: plan
+name: workflow-name
+description: Workflow description
+max_steps: 30
+initial_step: plan
+
+# Workflow-wide configuration
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
 
 # Section map (only when custom facets exist)
 personas:
@@ -78,11 +96,20 @@ knowledge:
 report_formats:
   custom-report: ../output-contracts/custom-report.md
 
-movements:
+steps:
   - name: plan
     edit: false
     persona: planner          # Builtin reference (bare name)
     knowledge: architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+          - WebSearch
+          - WebFetch
     instruction: plan
     output_contracts:
       report:
@@ -105,7 +132,9 @@ movements:
         next: review
 ```
 
-#### Parallel Movement Example
+**Compatibility aliases**: `movements` is synonymous with `steps`, `initial_movement` is synonymous with `initial_step`, `max_movements` is synonymous with `max_steps`. Use the canonical names for new workflows.
+
+#### Parallel Step Example
 
 ```yaml
   - name: reviewers
@@ -143,10 +172,11 @@ movements:
 
 | Decision Point | Criteria |
 |----------------|----------|
-| `edit: true/false` | Only true for movements that modify code |
-| `session: refresh` | Start a new session for implementation movements |
+| `edit: true/false` | Only true for steps that modify code |
+| `session: refresh` | Start a new session for implementation steps |
 | `pass_previous_response: false` | When you don't want review results passed directly |
 | `required_permission_mode` | Specify `edit` when edit permissions are needed |
+| `provider_options.claude.allowed_tools` | Restrict Claude's available tools per step |
 
 #### Rule Design
 
@@ -167,8 +197,8 @@ When custom facets are needed, create them following these conventions.
 
 ```
 ~/.takt/
-├── pieces/
-│   └── my-piece.yaml
+├── workflows/
+│   └── my-workflow.yaml
 ├── personas/
 │   └── custom-role.md
 ├── policies/
@@ -203,7 +233,7 @@ When custom facets are needed, create them following these conventions.
 - ...
 ```
 
-**Policy**: Behavioral guidelines shared across multiple movements.
+**Policy**: Behavioral guidelines shared across multiple steps.
 
 ```markdown
 # {Policy Name}
@@ -219,7 +249,7 @@ When custom facets are needed, create them following these conventions.
 - ...
 ```
 
-**Instruction**: Movement-specific procedures. Written in imperative form. `{task}` and `{previous_response}` are auto-injected, so they are not needed.
+**Instruction**: Step-specific procedures. Written in imperative form. `{task}` and `{previous_response}` are auto-injected, so they are not needed.
 
 **Knowledge**: Reference information that serves as the basis for judgment. Descriptive ("this is how it works").
 
@@ -248,15 +278,25 @@ Configure when fix loops are expected.
 
 ```yaml
 loop_monitors:
-  - cycle: [review, fix]
+  - cycle: [ai_review, ai_fix]
     threshold: 3
     judge:
       persona: supervisor
-      instruction: loop-monitor-review-fix
+      instruction: loop-monitor-ai-fix               # Builtin facet reference
       rules:
         - condition: Healthy (progress is being made)
-          next: review
+          next: ai_review
         - condition: Unproductive (no improvement)
+          next: reviewers
+  - cycle: [reviewers, fix]
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: loop-monitor-reviewers-fix        # Builtin facet reference
+      rules:
+        - condition: Healthy (issue count decreasing, fixes reflected)
+          next: reviewers
+        - condition: Unproductive (same issues repeating)
           next: supervise
 ```
 
@@ -264,10 +304,24 @@ loop_monitors:
 
 Verify the consistency of the created files:
 
-- [ ] Section map keys match the references within movements
-- [ ] Section map paths match actual file locations (relative paths from the piece YAML)
+- [ ] Section map keys match the references within steps
+- [ ] Section map paths match actual file locations (relative paths from the workflow YAML)
 - [ ] Builtin references (bare names) and custom references (section map keys) are not mixed improperly
-- [ ] `initial_movement` exists within the `movements` array
-- [ ] All movement `rules.next` values are valid transition targets (other movement names or COMPLETE/ABORT)
-- [ ] Parent rules of parallel movements use `all()` / `any()`
+- [ ] `initial_step` exists within the `steps` array
+- [ ] All step `rules.next` values are valid transition targets (other step names or COMPLETE/ABORT)
+- [ ] Parent rules of parallel steps use `all()` / `any()`
 - [ ] Parallel sub-step rules do not have `next` (parent controls transitions)
+
+## Validation
+
+Created/edited files can be mechanically verified with `validate-takt-files.sh`:
+
+```bash
+bash .agents/skills/takt-piece/scripts/validate-takt-files.sh
+```
+
+Verification items:
+- **Workflow YAML**: Required fields (`name`/`initial_step`/`steps`), `initial_step` step reference, facet file reference existence
+- **Facet .md**: Empty check, persona/policy/knowledge require `# heading`, instruction/output-contract require content
+
+Options `--pieces` / `--facets` can be used to narrow the scope.


### PR DESCRIPTION
- Apply same terminology renames (piece→workflow, movement→step) to all English skill files
- Update version to v0.35.4 in all SKILL.en.md
- Update builtin tables, reference paths, and field names

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to TAKT skill guides; low risk aside from potential user confusion if any renamed fields/paths are incorrect for v0.35.4.
> 
> **Overview**
> **Updates all `SKILL.en.md` guides to align with takt v0.35.4 terminology and file layout.** This standardizes `piece`→`workflow` and `movement`→`step`, updates required/target version strings, and refreshes reference paths (notably built-in facets under `references/takt/builtins/en/facets/...`).
> 
> **Expands and re-scopes skill responsibilities.** `takt-analyzer` now documents optional execution-log parsing/diagnostics (e.g., `matchedRuleMethod` distributions, loop hotspots, ABORT rates) and adds related triggers/checklists, while `takt-optimizer` removes direct log-reading guidance in favor of consuming `takt-analyze` diagnostic results.
> 
> **Improves workflow/task authoring guidance and validation.** `takt-workflow-builder` updates YAML examples/fields (`initial_step`, `max_steps`, `provider_options` structure, loop monitor examples) and adds validation-script instructions; `takt-task-builder` switches tasks.yaml examples from `piece` to `workflow`, updates status/validation guidance, and clarifies how to run bundled validators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774db4e03165c30ab3d62be88fd2738b426e3642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->