### PR TITLE
fix(takt-workflow-builder): update evals and validate script to workflow/step terminology

### DIFF
--- a/plugins/takt/skills/takt-workflow-builder/evals/evals.json
+++ b/plugins/takt/skills/takt-workflow-builder/evals/evals.json
@@ -1,57 +1,57 @@
 {
-  "skill_name": "takt-piece",
+  "skill_name": "takt-workflow-builder",
   "evals": [
     {
       "id": 1,
-      "prompt": "Rustのバックエンドプロジェクト用に、コードレビューと修正のサイクルを含むピースを作って。plan→implement→review→fixのループで、reviewでOKならCOMPLETE、修正が必要ならfixしてもう一度reviewへ。ピースとファセットは ~/.takt/ 以下に配置して。",
-      "expected_output": "plan→implement→review→fix→review のループ構成を持つピースYAMLが生成される。review は edit: false（Bash等のビルド系ツール不可）、implement/fix は edit: true + session: refresh。ビルトインファセットが最大限活用される。",
+      "prompt": "Rustのバックエンドプロジェクト用に、コードレビューと修正のサイクルを含むワークフローを作って。plan→implement→review→fixのループで、reviewでOKならCOMPLETE、修正が必要ならfixしてもう一度reviewへ。ワークフローとファセットは ~/.takt/ 以下に配置して。",
+      "expected_output": "plan→implement→review→fix→review のループ構成を持つワークフローYAMLが生成される。review は edit: false（Bash等のビルド系ツール不可）、implement/fix は edit: true + session: refresh。ビルトインファセットが最大限活用される。",
       "files": [],
       "expectations": [
-        "生成されたピースYAMLに name, initial_movement, movements の必須フィールドが存在する",
-        "initial_movement の値が movements 配列内のいずれかの name と一致する",
-        "review ムーブメントの edit が false に設定されている",
-        "fix ムーブメントの edit が true に設定されている",
+        "生成されたワークフローYAMLに name, initial_step, steps の必須フィールドが存在する",
+        "initial_step の値が steps 配列内のいずれかの name と一致する",
+        "review ステップの edit が false に設定されている",
+        "fix ステップの edit が true に設定されている",
         "allowed_tools が provider_options.claude.allowed_tools の形式で記述されている（v0.30.0形式）",
         "review の rules に fix への遷移と COMPLETE への遷移の両方が含まれている",
         "fix の rules に review への遷移が含まれている",
         "セクションマップで参照されているファセットファイルパスが実際に作成されている",
-        "review ムーブメントの allowed_tools に Bash が含まれていない（edit:false のため読み取り専用サンドボックスでビルドコマンドは実行不可）",
-        "implement および fix ムーブメントに session: refresh が設定されている",
+        "review ステップの allowed_tools に Bash が含まれていない（edit:false のため読み取り専用サンドボックスでビルドコマンドは実行不可）",
+        "implement および fix ステップに session: refresh が設定されている",
         "カスタムペルソナが5つ以下（ビルトイン planner/coder/architecture-reviewer 等を活用すべき）",
-        "implement ムーブメントが存在する（plan→review→fixではなくplan→implement→review→fix構成）"
+        "implement ステップが存在する（plan→review→fixではなくplan→implement→review→fix構成）"
       ]
     },
     {
       "id": 2,
-      "prompt": "フルスタック（React + Go）のプロジェクト向けに、plan→implement→並列レビュー（アーキテクチャ、フロントエンド、セキュリティ）→fix→supervise の構成でピースを作りたい。レビューとfixのループは3回で打ち切り。ピースとファセットは ~/.takt/ 以下に。",
-      "expected_output": "parallel ムーブメントで3つのレビュアーが並列実行され、all/any によるルール集約、loop_monitors による3回閾値のループ監視が設定されたピースYAMLが生成される。",
+      "prompt": "フルスタック（React + Go）のプロジェクト向けに、plan→implement→並列レビュー（アーキテクチャ、フロントエンド、セキュリティ）→fix→supervise の構成でワークフローを作りたい。レビューとfixのループは3回で打ち切り。ワークフローとファセットは ~/.takt/ 以下に。",
+      "expected_output": "parallel ステップで3つのレビュアーが並列実行され、all/any によるルール集約、loop_monitors による3回閾値のループ監視が設定されたワークフローYAMLが生成される。",
       "files": [],
       "expectations": [
-        "reviewers（または類似名）ムーブメントが parallel 構造を持ち、3つのサブムーブメントを含む",
+        "reviewers（または類似名）ステップが parallel 構造を持ち、3つのサブステップを含む",
         "parallel の親ルールが all() または any() 集約関数を使用している",
-        "parallel サブムーブメントの rules に next フィールドが含まれていない",
+        "parallel サブステップの rules に next フィールドが含まれていない",
         "loop_monitors が定義され、threshold が 3 に設定されている",
         "loop_monitors の健全時 next が cycle の先頭ノードと一致する",
         "allowed_tools が provider_options.claude.allowed_tools 形式で記述されている（v0.30.0形式）",
-        "implement ムーブメントに session: refresh が設定されている",
-        "全ムーブメントの rules.next が有効な遷移先（他のムーブメント名 or COMPLETE/ABORT）を指している",
-        "parallel サブムーブメント（レビュー系）の allowed_tools に Bash が含まれていない",
+        "implement ステップに session: refresh が設定されている",
+        "全ステップの rules.next が有効な遷移先（他のステップ名 or COMPLETE/ABORT）を指している",
+        "parallel サブステップ（レビュー系）の allowed_tools に Bash が含まれていない",
         "loop_monitors の instruction_template がビルトインテンプレート名を参照している（インラインテキストではない）"
       ]
     },
     {
       "id": 3,
-      "prompt": "ドキュメント生成用のピースを作りたい。ユーザーの要件をヒアリングして、Markdown形式のドキュメントを生成し、レビューして完了。シンプルに3ステップでいい。ビルトインのファセットで済むならカスタムは作らないで。出力先は ~/.takt/。",
-      "expected_output": "3ステップ構成のシンプルなピースが生成される。ビルトインのペルソナやポリシーが最大限活用され、カスタムファセットは必要最低限に抑えられる。",
+      "prompt": "ドキュメント生成用のワークフローを作りたい。ユーザーの要件をヒアリングして、Markdown形式のドキュメントを生成し、レビューして完了。シンプルに3ステップでいい。ビルトインのファセットで済むならカスタムは作らないで。出力先は ~/.takt/。",
+      "expected_output": "3ステップ構成のシンプルなワークフローが生成される。ビルトインのペルソナやポリシーが最大限活用され、カスタムファセットは必要最低限に抑えられる。",
       "files": [],
       "expectations": [
-        "movements が正確に3つ定義されている",
+        "steps が正確に3つ定義されている",
         "ビルトインペルソナ（planner, coder 等）が使用されており、不要なカスタムペルソナが作られていない",
         "output_contracts にレポート定義が含まれている（ドキュメント出力用）",
         "allowed_tools が provider_options.claude.allowed_tools 形式で記述されている（v0.30.0形式）",
         "validate-takt-files.sh による検証でエラーが出ない（スクリプトが利用可能な場合）",
         "カスタムファセットの総数が6つ以下（ビルトイン活用で最小限に抑えられている）",
-        "edit: false のムーブメントの allowed_tools に Bash が含まれていない"
+        "edit: false のステップの allowed_tools に Bash が含まれていない"
       ]
     }
   ]

--- a/plugins/takt/skills/takt-workflow-builder/scripts/validate-takt-files.sh
+++ b/plugins/takt/skills/takt-workflow-builder/scripts/validate-takt-files.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
 # validate-takt-files.sh
-# .takt/*/pieces/*.yaml と .takt/*/facets/**/*.md を検証する
+# .takt/*/workflows/*.yaml と .takt/*/facets/**/*.md を検証する
 #
 # 使用方法:
 #   ./scripts/validate-takt-files.sh             # 全ファイルを検証
 #   ./scripts/validate-takt-files.sh --quiet     # エラーと警告のみ表示
-#   ./scripts/validate-takt-files.sh --pieces    # ピースYAMLのみ
+#   ./scripts/validate-takt-files.sh --workflows # ワークフローYAMLのみ
 #   ./scripts/validate-takt-files.sh --facets    # ファセット.mdのみ
 #
 # 終了コード:
@@ -22,14 +22,14 @@ TAKT_DIR="${REPO_ROOT}/.takt"
 ERRORS=0
 WARNINGS=0
 QUIET=false
-CHECK_PIECES=true
+CHECK_WORKFLOWS=true
 CHECK_FACETS=true
 
 for arg in "$@"; do
   case "$arg" in
-    --quiet|-q)  QUIET=true ;;
-    --pieces)    CHECK_FACETS=false ;;
-    --facets)    CHECK_PIECES=false ;;
+    --quiet|-q)    QUIET=true ;;
+    --workflows)   CHECK_FACETS=false ;;
+    --facets)      CHECK_WORKFLOWS=false ;;
   esac
 done
 
@@ -95,13 +95,13 @@ validate_facet() {
 }
 
 # ──────────────────────────────────────
-# ピース YAML バリデーション
+# ワークフロー YAML バリデーション
 # ──────────────────────────────────────
-validate_piece() {
+validate_workflow() {
   local file="$1"
   local rel="${file#${REPO_ROOT}/}"
-  local piece_dir
-  piece_dir="$(dirname "$file")"
+  local workflow_dir
+  workflow_dir="$(dirname "$file")"
 
   info ""
   info "── ${rel}"
@@ -114,45 +114,57 @@ validate_piece() {
 
   # 必須フィールド: name
   if grep -qE "^name:[[:space:]]+.+" "$file"; then
-    local piece_name
-    piece_name=$(grep -E "^name:" "$file" | head -1 | sed 's/^name:[[:space:]]*//')
-    ok "name: ${piece_name}"
+    local workflow_name
+    workflow_name=$(grep -E "^name:" "$file" | head -1 | sed 's/^name:[[:space:]]*//')
+    ok "name: ${workflow_name}"
   else
     error "必須フィールド 'name' がありません（または空です）"
   fi
 
-  # 必須フィールド: initial_movement
-  local initial_movement=""
-  if grep -qE "^initial_movement:[[:space:]]+.+" "$file"; then
-    initial_movement=$(grep -E "^initial_movement:" "$file" | head -1 | sed 's/^initial_movement:[[:space:]]*//')
-    ok "initial_movement: ${initial_movement}"
+  # 必須フィールド: initial_step（エイリアス: initial_movement）
+  local initial_step=""
+  if grep -qE "^initial_step:[[:space:]]+.+" "$file"; then
+    initial_step=$(grep -E "^initial_step:" "$file" | head -1 | sed 's/^initial_step:[[:space:]]*//')
+    ok "initial_step: ${initial_step}"
+  elif grep -qE "^initial_movement:[[:space:]]+.+" "$file"; then
+    initial_step=$(grep -E "^initial_movement:" "$file" | head -1 | sed 's/^initial_movement:[[:space:]]*//')
+    warn "非推奨キー 'initial_movement' が使用されています。'initial_step' への移行を推奨します"
+    ok "initial_movement（→initial_step）: ${initial_step}"
   else
-    error "必須フィールド 'initial_movement' がありません（または空です）"
+    error "必須フィールド 'initial_step' がありません（または空です）"
   fi
 
-  # 必須フィールド: movements
-  if ! grep -qE "^movements:" "$file"; then
-    error "必須フィールド 'movements' がありません"
+  # 必須フィールド: steps（エイリアス: movements）
+  local steps_key=""
+  if grep -qE "^steps:" "$file"; then
+    steps_key="steps"
+  elif grep -qE "^movements:" "$file"; then
+    steps_key="movements"
+    warn "非推奨キー 'movements' が使用されています。'steps' への移行を推奨します"
+  fi
+
+  if [[ -z "$steps_key" ]]; then
+    error "必須フィールド 'steps' がありません"
     return
   fi
 
-  local movement_count
-  movement_count=$(grep -cE "^  - name:[[:space:]]+.+" "$file" || true)
-  if [[ "$movement_count" -eq 0 ]]; then
-    error "'movements' にエントリがありません"
+  local step_count
+  step_count=$(grep -cE "^  - name:[[:space:]]+.+" "$file" || true)
+  if [[ "$step_count" -eq 0 ]]; then
+    error "'${steps_key}' にエントリがありません"
     return
   fi
-  ok "movements: ${movement_count} 件"
+  ok "${steps_key}: ${step_count} 件"
 
-  # initial_movement が movements 内に存在するか
+  # initial_step が steps 内に存在するか
   # grep -F で固定文字列マッチし regex インジェクションを防ぐ
-  if [[ -n "$initial_movement" ]]; then
+  if [[ -n "$initial_step" ]]; then
     if grep -E "^  - name:[[:space:]]+" "$file" \
         | sed 's/^  - name:[[:space:]]*//' \
-        | grep -qxF "$initial_movement"; then
-      ok "initial_movement '${initial_movement}' → movement 存在確認"
+        | grep -qxF "$initial_step"; then
+      ok "initial_step '${initial_step}' → step 存在確認"
     else
-      error "initial_movement '${initial_movement}' が movements に定義されていません"
+      error "initial_step '${initial_step}' が ${steps_key} に定義されていません"
     fi
   fi
 
@@ -169,7 +181,7 @@ validate_piece() {
     while IFS= read -r facet_ref; do
       [[ -z "$facet_ref" ]] && continue
       local abs_path
-      abs_path=$(normalize_path "$piece_dir" "$facet_ref")
+      abs_path=$(normalize_path "$workflow_dir" "$facet_ref")
       if [[ -f "$abs_path" ]]; then
         ok "参照: ${facet_ref}"
       else
@@ -185,35 +197,35 @@ require "yaml"
 
 file = ARGV[0]
 doc = YAML.load_file(file)
-movements = doc["movements"] || []
+steps = doc["steps"] || doc["movements"] || []
 loop_monitors = doc["loop_monitors"] || []
 
-movement_reports = Hash.new { |h, k| h[k] = [] }
+step_reports = Hash.new { |h, k| h[k] = [] }
 
-report_names = lambda do |movement_node|
-  report_entries = movement_node.dig("output_contracts", "report") || []
+report_names = lambda do |step_node|
+  report_entries = step_node.dig("output_contracts", "report") || []
   report_entries.filter_map do |entry|
     name = entry.is_a?(Hash) ? entry["name"] : nil
     name unless name.nil? || name.empty?
   end
 end
 
-movements.each do |movement|
-  next unless movement.is_a?(Hash)
-  name = movement["name"]
+steps.each do |step|
+  next unless step.is_a?(Hash)
+  name = step["name"]
   next unless name && !name.empty?
-  movement_reports[name].concat(report_names.call(movement))
+  step_reports[name].concat(report_names.call(step))
 
-  parallel = movement["parallel"] || []
+  parallel = step["parallel"] || []
   parallel.each do |substep|
     sub_name = substep.is_a?(Hash) ? substep["name"] : nil
     next unless sub_name && !sub_name.empty?
     sub_reports = report_names.call(substep)
-    movement_reports[sub_name].concat(sub_reports)
-    movement_reports[name].concat(sub_reports)
-    movement_reports[sub_name].uniq!
+    step_reports[sub_name].concat(sub_reports)
+    step_reports[name].concat(sub_reports)
+    step_reports[sub_name].uniq!
   end
-  movement_reports[name].uniq!
+  step_reports[name].uniq!
 end
 
 loop_monitors.each_with_index do |monitor, idx|
@@ -223,9 +235,9 @@ loop_monitors.each_with_index do |monitor, idx|
   cycle = cycle.map(&:to_s)
   first = cycle[0]
 
-  cycle.each do |movement_name|
-    unless movement_reports.key?(movement_name) || movements.any? { |m| m.is_a?(Hash) && m["name"].to_s == movement_name }
-      puts "ERROR|loop_monitors[#{idx}]: cycle に未定義 movement '#{movement_name}' があります"
+  cycle.each do |step_name|
+    unless step_reports.key?(step_name) || steps.any? { |s| s.is_a?(Hash) && s["name"].to_s == step_name }
+      puts "ERROR|loop_monitors[#{idx}]: cycle に未定義 step '#{step_name}' があります"
     end
   end
 
@@ -247,11 +259,11 @@ loop_monitors.each_with_index do |monitor, idx|
 
   template = monitor.dig("judge", "instruction_template").to_s
   report_refs = template.scan(/\{report:([^}]+)\}/).flatten.uniq
-  allowed_reports = cycle.flat_map { |movement_name| movement_reports[movement_name] }.compact.uniq
+  allowed_reports = cycle.flat_map { |step_name| step_reports[step_name] }.compact.uniq
 
   report_refs.each do |report_name|
     unless allowed_reports.include?(report_name)
-      puts "ERROR|loop_monitors[#{idx}]: report '#{report_name}' は cycle 内 movement 生成物ではありません"
+      puts "ERROR|loop_monitors[#{idx}]: report '#{report_name}' は cycle 内 step 生成物ではありません"
     end
   end
 end
@@ -287,7 +299,7 @@ main() {
   fi
 
   local facet_count=0
-  local piece_count=0
+  local workflow_count=0
 
   # ──── ファセット検証 ────
   if [[ "$CHECK_FACETS" == true ]]; then
@@ -310,24 +322,24 @@ main() {
     done
   fi
 
-  # ──── ピース検証 ────
-  if [[ "$CHECK_PIECES" == true ]]; then
+  # ──── ワークフロー検証 ────
+  if [[ "$CHECK_WORKFLOWS" == true ]]; then
     info ""
-    info "=== ピース (.yaml) チェック ==="
+    info "=== ワークフロー (.yaml) チェック ==="
 
     while IFS= read -r file; do
-      validate_piece "$file"
-      piece_count=$((piece_count + 1))
-    done < <(find "${TAKT_DIR}" -path "*/pieces/*.yaml" -print 2>/dev/null | sort)
+      validate_workflow "$file"
+      workflow_count=$((workflow_count + 1))
+    done < <(find "${TAKT_DIR}" -path "*/workflows/*.yaml" -print 2>/dev/null | sort)
 
-    if [[ "$piece_count" -eq 0 ]]; then
-      info "  ピースファイルが見つかりませんでした"
+    if [[ "$workflow_count" -eq 0 ]]; then
+      info "  ワークフローファイルが見つかりませんでした"
     fi
   fi
 
   info ""
   info "────────────────────────────────────────"
-  echo "ファセット: ${facet_count} / ピース: ${piece_count} | エラー: ${ERRORS} | 警告: ${WARNINGS}"
+  echo "ファセット: ${facet_count} / ワークフロー: ${workflow_count} | エラー: ${ERRORS} | 警告: ${WARNINGS}"
 
   if [[ "$ERRORS" -gt 0 ]]; then
     exit 1


### PR DESCRIPTION
## 変更内容

### evals/evals.json
- `skill_name`: `"takt-piece"` → `"takt-workflow-builder"`
- 全 eval の prompt/expected_output/expectations: ピース→ワークフロー、ムーブメント→ステップ
- キー表記: `initial_movement`/`movements` → `initial_step`/`steps`

### scripts/validate-takt-files.sh
- `--pieces` フラグ → `--workflows`、`CHECK_PIECES` → `CHECK_WORKFLOWS`
- `validate_piece()` → `validate_workflow()`
- 検証ロジック: `initial_step`/`steps` を正規キーとして優先。旧キー `initial_movement`/`movements` は `warn` 付きエイリアスとして許容（後方互換）
- `find` パス `*/pieces/` → `*/workflows/`
- Ruby スクリプト内の変数名 `movements`/`movement_*` → `steps`/`step_*`
- サマリー表示: 「ピース」→「ワークフロー」

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the validation script’s CLI flags and the YAML file discovery path from `pieces` to `workflows`, which can break existing automation. YAML schema support is mostly safe due to `initial_movement`/`movements` being accepted with warnings.
> 
> **Overview**
> Updates `takt-workflow-builder` eval definitions to consistently use **workflow/step** terminology (including `initial_step`/`steps`) and fixes `skill_name` to `takt-workflow-builder`.
> 
> Refactors `validate-takt-files.sh` to validate `.takt/*/workflows/*.yaml` (new `--workflows` flag, renamed validator, updated counters/messages) and to treat `initial_step`/`steps` as canonical while still accepting deprecated `initial_movement`/`movements` with warnings; the Ruby `loop_monitors` checks are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05100c26af5b2f0311b930616d5fed771e649f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->