### PR TITLE
[codex] 空の changelog でも手動リリースを進める

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           release-count: '0'
           version-file: 'package.json'
           version-path: 'version'
-          skip-on-empty: 'true'
+          skip-on-empty: 'false'
           skip-commit: ${{ inputs.dry_run || false }}
           skip-tag: ${{ inputs.dry_run || false }}
           skip-git-pull: 'true'


### PR DESCRIPTION
## 概要

- 手動 release workflow で changelog が空でも release を skip しないようにしました。
- 直近 run では chore 系 commit だけのため skip-on-empty により Push Changes / Create GitHub Release が skip されていました。

## 検証

- yq '.' .github/workflows/release.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow flag change; affects release automation only, with no application runtime impact.
> 
> **Overview**
> The manual **Release** workflow now sets `skip-on-empty: 'false'` on `TriPSs/conventional-changelog-action`, so a run is not treated as skipped when conventional changelog generation finds no releasable commits (e.g. only `chore` commits).
> 
> That should allow **Push Changes** and **Create GitHub Release** to run when you intentionally trigger a release, instead of exiting early because the changelog section is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cb806054f7524a3667a5520a461724d630a48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->