### PR TITLE
Fix/skills update

### DIFF
--- a/.agents/skills/kiro-review/SKILL.md
+++ b/.agents/skills/kiro-review/SKILL.md
@@ -10,7 +10,7 @@ This skill performs task-local adversarial review. It verifies that the implemen
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
-- design fixes `Boundary Commitments`
+- design fixes the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - tasks constrain execution with `_Boundary:_`
 - review rejects concrete `Boundary Violations`
 </background_information>
@@ -31,7 +31,8 @@ Provide:
 - Task ID and exact task text from `tasks.md`
 - Relevant requirement section numbers
 - Relevant design section numbers
-- Spec file paths (`requirements.md`, `design.md`, optionally `tasks.md`)
+- Spec file paths (`spec.json`, `requirements.md`, `design.md`, optionally `tasks.md`)
+- `.kiro/settings/templates/specs/localized-spec-terminology.md` for language-specific boundary terms
 - The implementer's status report
 - The task `_Boundary:_` scope constraints
 - Validation commands discovered by the controller
@@ -111,7 +112,7 @@ Run these checks and use the result as primary signal.
 - Reject silent substitutions for design-mandated choices.
 
 ### 10.5 Boundary Audit
-- Compare the implementation against the design's boundary commitments and out-of-boundary statements.
+- Compare the implementation against the design boundary and out-of-boundary terms named by `.kiro/settings/templates/specs/localized-spec-terminology.md`, using `spec.json.language` to select the artifact language.
 - Reject if downstream-specific behavior is pushed into an upstream boundary for convenience.
 - Reject if the implementation creates new hidden dependencies, shared ownership, or undeclared coupling across adjacent boundaries.
 - Reject if a task that is not an explicit integration task now behaves like one.

--- a/.agents/skills/kiro-spec-design/SKILL.md
+++ b/.agents/skills/kiro-spec-design/SKILL.md
@@ -2,6 +2,7 @@
 name: kiro-spec-design
 description: Create comprehensive technical design for a specification
 metadata:
+  cross-skill-rules: ".kiro/settings/templates/specs/localized-spec-terminology.md"
   shared-rules: "design-principles.md, design-discovery-full.md, design-discovery-light.md, design-synthesis.md, design-review-gate.md"
 ---
 
@@ -27,9 +28,10 @@ metadata:
 - `.kiro/specs/$1/research.md` (if exists, contains gap analysis from `$kiro-validate-gap`)
 - Core steering context: `product.md`, `tech.md`, `structure.md`
 - Additional steering files only when directly relevant to requirement coverage, architecture boundaries, integrations, runtime prerequisites, security/performance constraints, or team conventions that affect implementation readiness
-- `.kiro/settings/templates/specs/design.md` for document structure
+- Select the matching design template from `spec.json.language`: `.kiro/settings/templates/specs/design.md` for `ja`, or `.kiro/settings/templates/specs/design.en.md` for `en`. Stop for missing or unsupported languages.
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` for localized spec terms
 - Read `rules/design-principles.md` from this skill's directory for design principles
-- `.kiro/settings/templates/specs/research.md` for discovery log structure
+- Select the matching research template from `spec.json.language`: `.kiro/settings/templates/specs/research.md` for `ja`, or `.kiro/settings/templates/specs/research.en.md` for `en`. Stop for unsupported languages.
 
 **Validate requirements approval**:
 - If `-y` flag provided ($2 == "-y"): Auto-approve requirements in spec.json
@@ -85,7 +87,7 @@ After all findings return, synthesize in main context before proceeding.
    - Boundary candidates, out-of-boundary decisions, and likely revalidation triggers
 
 4. **Persist Findings to Research Log**:
-   - Create or update `.kiro/specs/$1/research.md` using the shared template
+   - Create or update `.kiro/specs/$1/research.md` using the selected research template
    - Summarize discovery scope and key findings (Summary section)
    - Record investigations in Research Log topics with sources and implications
    - Document architecture pattern evaluation, design decisions, and risks using the template sections
@@ -102,14 +104,14 @@ After all findings return, synthesize in main context before proceeding.
 ### Step 4: Generate Design Draft
 
 1. **Load Design Template and Rules**:
-   - Read `.kiro/settings/templates/specs/design.md` for structure
+   - Select the matching design template from `spec.json.language`: `.kiro/settings/templates/specs/design.md` for `ja`, or `.kiro/settings/templates/specs/design.en.md` for `en`. Stop for unsupported languages.
    - Read `rules/design-principles.md` from this skill's directory for principles
 
 2. **Generate Design Draft**:
-   - **Follow specs/design.md template structure and generation instructions strictly**
+   - **Follow the selected design template structure and generation instructions strictly**
    - **Boundary-first requirement**: Before expanding supporting sections, make the boundary explicit. The draft must clearly define what this spec owns, what it does not own, which dependencies are allowed, and what changes would require downstream revalidation.
    - **Integrate all discovery findings and synthesis outcomes**: Use researched information (APIs, patterns, technologies) and synthesis decisions (generalizations, build-vs-adopt, simplifications) throughout component definitions, architecture decisions, and integration points
-   - **File Structure Plan** (required): Populate the File Structure Plan section with concrete file paths and responsibilities. Analyze the codebase to determine which files need to be created vs. modified. Each file must have one clear responsibility. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs — vague file structures produce vague implementations.
+   - **File structure plan** (required): Populate the file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` with concrete file paths and responsibilities. Analyze the codebase to determine which files need to be created vs. modified. Each file must have one clear responsibility. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs — vague file structures produce vague implementations.
    - **Testing Strategy**: Derive test items from requirements' acceptance criteria, not generic patterns. Each test item should reference specific components and behaviors from this design. E2E paths must map to the critical user flows identified in requirements. Avoid vague entries like "test login works" -- instead specify what is being verified and why it matters.
    - If existing design.md found in Step 1, use it as reference context (merge mode)
    - Apply design rules: Type Safety, Visual Communication, Formal Tone
@@ -162,7 +164,7 @@ Provide brief summary in the language specified in spec.json:
 
 **Format**: Concise Markdown (under 200 words) - this is the command output, NOT the design document itself
 
-**Note**: The actual design document follows `.kiro/settings/templates/specs/design.md` structure.
+**Note**: The actual design document follows the selected design template structure for `spec.json.language`.
 
 ## Safety & Fallback
 
@@ -179,9 +181,9 @@ Provide brief summary in the language specified in spec.json:
 - **Suggested Action**: "Run `$kiro-spec-requirements $1` to generate requirements first"
 
 **Template Missing**:
-- **User Message**: "Template file missing at `.kiro/settings/templates/specs/design.md`"
+- **Stop Execution**: The selected language-specific design template, research template, and localized terminology file must exist
+- **User Message**: "Template file missing for selected spec language"
 - **Suggested Action**: "Check repository setup or restore template file"
-- **Fallback**: Use inline basic structure with warning
 
 **Steering Context Missing**:
 - **Warning**: "Steering directory empty or missing - design may not align with project standards"

--- a/.agents/skills/kiro-spec-design/rules/design-principles.md
+++ b/.agents/skills/kiro-spec-design/rules/design-principles.md
@@ -30,7 +30,7 @@
 ### 4. Component Design Rules
 - **Single Responsibility**: One clear purpose per component
 - **Clear Boundaries**: Explicit domain ownership
-- **Boundary Commitments First**: Before detailing components, state the responsibility boundary this design commits to
+- **Boundary Commitments First**: Before detailing components, state the responsibility boundary this design commits to using the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - **Dependency Direction**: Follow architectural layers
 - **Interface Segregation**: Minimal, focused interfaces
 - **Team-safe Interfaces**: Design boundaries that allow parallel implementation without merge conflicts
@@ -60,7 +60,7 @@
 - **Define and enforce the dependency direction** in the architecture section of design.md (e.g., Types → Config → Repository → Service → Runtime → UI)
 - Each layer imports only from layers to its left — never upward
 - This constraint is not a suggestion; implementation and review should treat violations as errors
-- When the File Structure Plan maps files to components, the dependency direction determines which imports are allowed
+- When the file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` maps files to components, the dependency direction determines which imports are allowed
 
 ## Documentation Standards
 
@@ -80,14 +80,14 @@
 ## Section Authoring Guidance
 
 ### Global Ordering
-- Default flow: Overview → Goals/Non-Goals → Boundary Commitments → Architecture → File Structure Plan → Components & Interfaces → Optional sections.
+- Follow the selected language-specific design template from `spec.json.language` (`design.md` for `ja`, `design.en.md` for `en`) and keep section headings intact for the artifact language.
 - Teams may swap Traceability earlier or place Data Models nearer Architecture when it improves clarity, but keep section headings intact.
 - Within each section, follow **Summary → Scope → Decisions → Impacts/Risks** so reviewers can scan consistently.
 
 ### Requirement IDs
 - Reference requirements as `2.1, 2.3` without prefixes (no “Requirement 2.1”).
 - All requirements MUST have numeric IDs. If a requirement lacks a numeric ID, stop and fix `requirements.md` before continuing.
-- Use `N.M`-style numeric IDs where `N` is the top-level requirement number from requirements.md (for example, Requirement 1 → 1.1, 1.2; Requirement 2 → 2.1, 2.2).
+- Use `N.M`-style numeric IDs where `N` is the top-level requirement number from requirements.md, regardless of whether the requirement heading uses the Japanese or English term from `.kiro/settings/templates/specs/localized-spec-terminology.md`.
 - Every component, task, and traceability row must reference the same canonical numeric ID.
 
 ### Technology Stack
@@ -102,14 +102,14 @@
   - **Data/Event** for pipelines or async patterns
 - Always use pure Mermaid. If no complex flow exists, omit the entire section.
 
-### Requirements Traceability
-- Use the standard table (`Requirement | Summary | Components | Interfaces | Flows`) to prove coverage.
+### Traceability Section
+- Use the table language that matches the artifact language to prove coverage.
 - Collapse to bullet form only when a single requirement maps 1:1 to a component.
 - Prefer the component summary table for simple mappings; reserve the full traceability table for complex or compliance-sensitive requirements.
 - Re-run this mapping whenever requirements or components change to avoid drift.
 
 ### Components & Interfaces Authoring
-- Boundary Commitments should already make the ownership seam explicit before this section begins.
+- The design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` should already make the ownership boundary explicit before this section begins.
 - Group components by domain/layer and provide one block per component.
 - Begin with a summary table listing Component, Domain, Intent, Requirement coverage, key dependencies, and selected contracts.
 - Table fields: Intent (one line), Requirements (`2.1, 2.3`), Owner/Reviewers (optional).

--- a/.agents/skills/kiro-spec-design/rules/design-review-gate.md
+++ b/.agents/skills/kiro-spec-design/rules/design-review-gate.md
@@ -36,11 +36,12 @@ Before writing `design.md`, review the draft design and repair local issues unti
 ## Mechanical Checks
 
 Before applying judgment, verify these mechanically:
-- **Requirements traceability**: Extract all numeric requirement IDs from `requirements.md`. Scan the design draft for each ID. Report any IDs not found in the design.
-- **Boundary section populated**: `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers` must not be empty or placeholder-only.
-- **File Structure Plan populated**: The File Structure Plan section must contain concrete file paths (not just "TBD" or empty). Scan for placeholder text in that section.
-- **Boundary ↔ file structure alignment**: The File Structure Plan must reflect the stated responsibility boundary. If files imply broader ownership than the boundary section claims, report a mismatch.
-- **No orphan components**: Every component mentioned in the design must appear in the File Structure Plan with a file path. Scan for component names that have no corresponding file entry.
+- **Artifact language selected**: Read `spec.json.language` before section-name checks. Use the matching Japanese or English terms from `.kiro/settings/templates/specs/localized-spec-terminology.md`. If the language is missing or unsupported, or the localized terminology file is missing, stop and clarify the target language or repository setup before applying this gate.
+- **Requirements traceability**: Extract all numeric requirement IDs from `requirements.md` using the requirement heading form for `spec.json.language` from `.kiro/settings/templates/specs/localized-spec-terminology.md`; also accept existing hybrid headings that use the alternate Japanese/English heading term and existing numeric requirement list items. Scan the design draft for each ID. Report any IDs not found in the design.
+- **Boundary section populated**: The design boundary section and boundary subsections named by `.kiro/settings/templates/specs/localized-spec-terminology.md` must not be empty or placeholder-only. Also accept existing hybrid headings that use the alternate Japanese/English heading terms from the same terminology row.
+- **File structure section populated**: The file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` must contain concrete file paths (not just "TBD" or empty). Also accept the alternate Japanese/English file structure heading from the same terminology row. Scan for placeholder text in that section.
+- **Boundary ↔ file structure alignment**: The file structure section must reflect the stated responsibility boundary. If files imply broader ownership than the boundary section claims, report a mismatch.
+- **No orphan components**: Every component mentioned in the design must appear in the file structure section with a file path. Scan for component names that have no corresponding file entry.
 
 ## Review Loop
 

--- a/.agents/skills/kiro-spec-init/SKILL.md
+++ b/.agents/skills/kiro-spec-init/SKILL.md
@@ -17,12 +17,14 @@ Generate a unique feature name from the project description ($ARGUMENTS) and ini
 4. **Create Directory**: `.kiro/specs/[feature-name]/` (skip if already exists from discovery)
 5. **Initialize Files Using Templates**:
    - Read `.kiro/settings/templates/specs/init.json`
-   - Read `.kiro/settings/templates/specs/requirements-init.md`
+   - Detect the language code from the selected project description source: use brief.md content when present, otherwise use the user's input language. If uncertain, select `ja` as the repository default.
+   - Select the matching requirements skeleton: `.kiro/settings/templates/specs/requirements-init.md` for `ja`, or `.kiro/settings/templates/specs/requirements-init.en.md` for `en`. Stop for unsupported languages.
    - Replace placeholders:
      - `{{FEATURE_NAME}}` → generated feature name
      - `{{TIMESTAMP}}` → current ISO 8601 timestamp
      - `{{PROJECT_DESCRIPTION}}` → from brief.md if available, otherwise $ARGUMENTS
-     - `ja` → language code (detect from user's input language, default to `en`)
+     - `{{LANGUAGE}}` → selected language code
+   - Ensure the selected language code and requirements skeleton language match before writing files
    - Write `spec.json` and `requirements.md` to spec directory
 
 ## Important Constraints
@@ -46,6 +48,6 @@ Provide output in the language specified in `spec.json` with the following struc
 ## Safety & Fallback
 - **Ambiguous Feature Name**: If feature name generation is unclear, propose 2-3 options and ask user to select
 - **Template Missing**: If template files don't exist in `.kiro/settings/templates/specs/`, report error with specific missing file path and suggest checking repository setup
+- **Unsupported Language**: If language detection selects a code without a requirements skeleton, stop and report the unsupported language instead of mixing metadata and template languages
 - **Directory Conflict**: If feature name already exists, append numeric suffix (e.g., `feature-name-2`) and notify user of automatic conflict resolution
 - **Write Failure**: Report error with specific path and suggest checking permissions or disk space
-

--- a/.agents/skills/kiro-spec-quick/SKILL.md
+++ b/.agents/skills/kiro-spec-quick/SKILL.md
@@ -70,21 +70,28 @@ Execute these 4 phases in order:
 
 5. **Initialize Files from Templates**:
 
-   a. Read templates:
+   a. Select language:
+   ```
+   selected language code → detect from the selected project description source: use brief.md content when present, otherwise use user's input language; if uncertain, select `ja` as the repository default
+   ```
+   Stop for unsupported languages. Use this same selected language code for `spec.json` and the requirements skeleton.
+
+   b. Read templates:
    ```
    - .kiro/settings/templates/specs/init.json
-   - .kiro/settings/templates/specs/requirements-init.md
+   - .kiro/settings/templates/specs/requirements-init.md for `ja`, or .kiro/settings/templates/specs/requirements-init.en.md for `en`
    ```
 
-   b. Replace placeholders:
+   c. Replace placeholders:
    ```
    {{FEATURE_NAME}} → feature-name
    {{TIMESTAMP}} → current ISO 8601 timestamp (use `date -u +"%Y-%m-%dT%H:%M:%SZ"`)
    {{PROJECT_DESCRIPTION}} → description
-   ja → language code (detect from user's input language, default to `en`)
+   {{LANGUAGE}} → selected language code
    ```
+   Ensure the selected language code and requirements skeleton language match before writing files.
 
-   c. Write files using Write tool:
+   d. Write files using Write tool:
    ```
    - .kiro/specs/{feature-name}/spec.json
    - .kiro/specs/{feature-name}/requirements.md

--- a/.agents/skills/kiro-spec-requirements/SKILL.md
+++ b/.agents/skills/kiro-spec-requirements/SKILL.md
@@ -31,7 +31,8 @@ metadata:
 2. **Read Guidelines**:
    - Read `rules/ears-format.md` from this skill's directory for EARS syntax rules
    - Read `rules/requirements-review-gate.md` from this skill's directory for pre-write review criteria
-   - Read `.kiro/settings/templates/specs/requirements.md` for document structure
+   - Read `.kiro/settings/templates/specs/localized-spec-terminology.md` for localized spec terms
+   - Select the matching requirements template from `spec.json.language`: `.kiro/settings/templates/specs/requirements.md` for `ja`, or `.kiro/settings/templates/specs/requirements.en.md` for `en`. Stop for unsupported languages.
 
 #### Parallel Research (sub-agent dispatch)
 
@@ -59,7 +60,7 @@ After all research completes, synthesize findings in main context before generat
    - Preserve terminology continuity across phases:
      - discovery = `Boundary Candidates`
      - requirements = explicit inclusion/exclusion and adjacent expectations when needed
-     - design = `Boundary Commitments`
+     - design = design boundary section from `.kiro/settings/templates/specs/localized-spec-terminology.md`
      - tasks = `_Boundary:_`
    - If scope could be misread, add lightweight boundary context without introducing implementation or architecture ownership detail
    - Keep this as a draft until the review gate passes; do not write `requirements.md` yet
@@ -101,7 +102,7 @@ Requirements describe user-observable behavior, not implementation. Use this to 
 ### Other Constraints
 - Each requirement must be testable and unambiguous. If the project description leaves room for multiple interpretations on scope, behavior, or boundary conditions, ask the user to clarify before generating that requirement. Ask as many questions as needed; do not generate requirements that contain your own assumptions.
 - Choose appropriate subject for EARS statements (system/service name for software)
-- Requirement headings in requirements.md MUST include a leading numeric ID only (for example: "Requirement 1", "1.", "2 Feature ..."); do not use alphabetic IDs like "Requirement A".
+- Requirement headings in requirements.md MUST include a leading numeric ID only. New or rewritten headings should use the form for `spec.json.language` from `.kiro/settings/templates/specs/localized-spec-terminology.md`; existing hybrid headings using the alternate Japanese/English term remain valid if the numeric ID is present. Do not use alphabetic IDs like "要件 A" or "Requirement A".
 </instructions>
 
 ## Output Description
@@ -121,11 +122,11 @@ Provide output in the language specified in spec.json with:
 
 ### Error Scenarios
 - **Missing Project Description**: If requirements.md lacks project description, ask user for feature details
-- **Template Missing**: If template files don't exist, use inline fallback structure with warning
-- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+- **Template Missing**: Stop if the selected language-specific requirements template or localized terminology file is missing
+- **Language Undefined**: Stop and clarify the target language if `spec.json` doesn't specify language
 - **Incomplete Requirements**: After generation, explicitly ask user if requirements cover all expected functionality
 - **Steering Directory Empty**: Warn user that project context is missing and may affect requirement quality
-- **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
+- **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "要件 A" or "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
 - **Scope Ambiguity Found During Requirements Review**: Stop execution, do not write a guessed `requirements.md`, and ask the user to clarify the missing or conflicting scope before re-running `$kiro-spec-requirements $1`
 
 ### Next Phase: Design Generation

--- a/.agents/skills/kiro-spec-requirements/rules/ears-format.md
+++ b/.agents/skills/kiro-spec-requirements/rules/ears-format.md
@@ -1,49 +1,66 @@
 # EARS Format Guidelines
 
 ## Overview
+
 EARS (Easy Approach to Requirements Syntax) is the standard format for acceptance criteria in spec-driven development.
 
-EARS patterns describe the logical structure of a requirement (condition + subject + response) and are not tied to any particular natural language.  
-All acceptance criteria should be written in the target language configured for the specification (for example, `spec.json.language` / `ja`).  
-Keep EARS trigger keywords and fixed phrases in English (`When`, `If`, `While`, `Where`, `The system shall`, `The [system] shall`) and localize only the variable parts (`[event]`, `[precondition]`, `[trigger]`, `[feature is included]`, `[response/action]`) into the target language. Do not interleave target-language text inside the trigger or fixed English phrases themselves.
+EARS patterns describe the logical structure of a requirement: condition, subject, and response.
+They are not tied to English wording.
+All acceptance criteria should be written in the target language configured for the specification, such as `spec.json.language`.
+
+For Japanese specifications (`language: "ja"`), use Japanese EARS fixed phrases.
+Do not force English trigger words such as `When`, `If`, `While`, `Where`, or `shall` into Japanese requirements.
+Existing hybrid Japanese specs with English EARS triggers remain valid for review, but new or rewritten Japanese criteria should use the Japanese phrases.
 
 ## Primary EARS Patterns
 
 ### 1. Event-Driven Requirements
-- **Pattern**: When [event], the [system] shall [response/action]
+- **English Pattern**: When [event], the [system] shall [response/action]
+- **Japanese Pattern**: [イベント] が起きたとき、[システム] は [応答] しなければならない
 - **Use Case**: Responses to specific events or triggers
-- **Example**: When user clicks checkout button, the Checkout Service shall validate cart contents
+- **Example**: ユーザーがチェックアウトボタンをクリックしたとき、Checkout Service はカート内容を検証しなければならない
 
 ### 2. State-Driven Requirements
-- **Pattern**: While [precondition], the [system] shall [response/action]
+- **English Pattern**: While [precondition], the [system] shall [response/action]
+- **Japanese Pattern**: [前提] の間、[システム] は [応答] し続けなければならない
 - **Use Case**: Behavior dependent on system state or preconditions
-- **Example**: While payment is processing, the Checkout Service shall display loading indicator
+- **Example**: 支払い処理中の間、Checkout Service はローディング状態を表示し続けなければならない
 
 ### 3. Unwanted Behavior Requirements
-- **Pattern**: If [trigger], the [system] shall [response/action]
+- **English Pattern**: If [trigger], the [system] shall [response/action]
+- **Japanese Pattern**: [条件/異常] の場合、[システム] は [応答] しなければならない
 - **Use Case**: System response to errors, failures, or undesired situations
-- **Example**: If invalid credit card number is entered, then the website shall display error message
+- **Example**: 無効なカード番号が入力された場合、Checkout Service はエラーメッセージを表示しなければならない
 
 ### 4. Optional Feature Requirements
-- **Pattern**: Where [feature is included], the [system] shall [response/action]
+- **English Pattern**: Where [feature is included], the [system] shall [response/action]
+- **Japanese Pattern**: [機能/オプション] を含む場合、[システム] は [応答] しなければならない
 - **Use Case**: Requirements for optional or conditional features
-- **Example**: Where the car has a sunroof, the car shall have a sunroof control panel
+- **Example**: クーポン機能を含む場合、Checkout Service は割引額を注文合計に反映しなければならない
 
 ### 5. Ubiquitous Requirements
-- **Pattern**: The [system] shall [response/action]
+- **English Pattern**: The [system] shall [response/action]
+- **Japanese Pattern**: [システム] は常に [応答] しなければならない
 - **Use Case**: Always-active requirements and fundamental system properties
-- **Example**: The mobile phone shall have a mass of less than 100 grams
+- **Example**: Checkout Service は常に注文合計を税込金額で表示しなければならない
 
 ## Combined Patterns
-- While [precondition], when [event], the [system] shall [response/action]
-- When [event] and [additional condition], the [system] shall [response/action]
+
+- **English Pattern**: While [precondition], when [event], the [system] shall [response/action]
+- **English Pattern**: When [event] and [additional condition], the [system] shall [response/action]
+- [前提] の間、[イベント] が起きたとき、[システム] は [応答] しなければならない
+- [イベント] が起き、かつ [追加条件] の場合、[システム] は [応答] しなければならない
 
 ## Subject Selection Guidelines
-- **Software Projects**: Use concrete system/service name (e.g., "Checkout Service", "User Auth Module")
-- **Process/Workflow**: Use responsible team/role (e.g., "Support Team", "Review Process")
-- **Non-Software**: Use appropriate subject (e.g., "Marketing Campaign", "Documentation")
+
+- **Software Projects**: Use concrete system/service name, such as `Calendar Sync MVP`.
+- **Process/Workflow**: Use responsible team/role, such as `Support Team`.
+- **Non-Software**: Use appropriate subject, such as `Marketing Campaign`.
 
 ## Quality Criteria
+
 - Requirements must be testable, verifiable, and describe a single behavior.
-- Use objective language: "shall" for mandatory behavior, "should" for recommendations; avoid ambiguous terms.
-- Follow EARS syntax: [condition], the [system] shall [response/action].
+- Use objective mandatory language: in English, use `shall` for mandatory behavior; in Japanese, prefer `しなければならない`.
+- Avoid vague words such as `appropriate`, `where possible`, `適切に`, `できるだけ`, or `なるべく`.
+- Follow an EARS logical pattern even when localized into Japanese.
+- Keep implementation details out of requirements unless they are directly user- or operator-observable constraints.

--- a/.agents/skills/kiro-spec-requirements/rules/requirements-review-gate.md
+++ b/.agents/skills/kiro-spec-requirements/rules/requirements-review-gate.md
@@ -8,7 +8,7 @@ Use boundary terminology consistently across phases without turning requirements
 
 - **Discovery** identifies `Boundary Candidates`
 - **Requirements** make inclusion, exclusion, and adjacent expectations explicit when scope could be misread
-- **Design** turns those into `Boundary Commitments`
+- **Design** turns those into the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - **Tasks** use `_Boundary:_` to constrain executable work
 
 Requirements should clarify the feature boundary in user- or operator-observable terms, not in architecture ownership or implementation detail.
@@ -26,7 +26,7 @@ Requirements should clarify the feature boundary in user- or operator-observable
 - Every acceptance criterion must follow the EARS rules defined in `ears-format.md`.
 - Every requirement must be testable, observable, and specific enough that later design and validation can verify it.
 - Remove implementation details that belong in `design.md` rather than `requirements.md`.
-- Requirement headings must use numeric IDs only; do not mix numeric and alphabetic labels.
+- Requirement headings must use numeric IDs only. Prefer the heading form for `spec.json.language` from `.kiro/settings/templates/specs/localized-spec-terminology.md`; also accept existing hybrid headings that use the alternate Japanese/English heading term with a numeric ID. Do not mix numeric and alphabetic labels.
 
 ## Structure and Quality Review
 
@@ -40,7 +40,7 @@ Requirements should clarify the feature boundary in user- or operator-observable
 
 Before applying judgment, verify these mechanically:
 - **Numeric IDs present**: Every requirement heading has a numeric ID (1, 1.1, 2, etc.). Scan the draft for headings without IDs.
-- **Acceptance criteria exist**: Every requirement has at least one EARS-format acceptance criterion. Scan for requirements with no "When/If/While/Where" acceptance statements.
+- **Acceptance criteria exist**: Every requirement has at least one EARS-format acceptance criterion. Read `spec.json.language` first and choose the matching scan. For `language: "en"`, scan for conditional EARS trigger words such as "When", "If", "While", or "Where", and verify ubiquitous criteria by mandatory `shall` wording so named subjects such as service names are accepted. For `language: "ja"`, prefer localized EARS fixed phrases such as "が起きたとき", "の場合", "の間", "を含む場合", or "は常に", and verify the criterion also uses mandatory wording such as "しなければならない" or state-continuation wording such as "し続けなければならない"; also accept existing hybrid criteria that use English EARS trigger words and mandatory `shall` wording. If the language is missing or unsupported, stop and clarify the target language before applying this gate.
 - **No implementation language**: Scan for technology-specific terms (database names, framework names, API patterns) that belong in design, not requirements. Flag any found.
 
 ## Review Loop

--- a/.agents/skills/kiro-spec-status/SKILL.md
+++ b/.agents/skills/kiro-spec-status/SKILL.md
@@ -23,6 +23,7 @@ description: Show specification status and progress
 - Read existing files: `requirements.md`, `design.md`, `tasks.md` (if they exist)
 - Check `.kiro/specs/$1/` directory for available files
 - Read `.kiro/steering/roadmap.md` if it exists and this spec appears in it
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` and select section names from `spec.json.language`; stop if the language is missing or unsupported
 
 ### Step 2: Analyze Status
 
@@ -33,7 +34,7 @@ description: Show specification status and progress
 - **Approvals**: Check approval status in spec.json
 - **Boundary context**:
   - From brief.md: note `Boundary Candidates`, `Upstream / Downstream`, and `Existing Spec Touchpoints` if present
-  - From design.md: note `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers` if present
+  - From design.md: note boundary terms using the selected localized terminology for this spec
   - From roadmap.md: note upstream dependencies and whether this spec is adjacent to `Existing Spec Updates`
 - **Revalidation watchlist**:
   - Identify downstream specs, neighboring existing-spec updates, or rollout-sensitive design notes that may need revalidation if this spec changes

--- a/.agents/skills/kiro-spec-tasks/SKILL.md
+++ b/.agents/skills/kiro-spec-tasks/SKILL.md
@@ -27,6 +27,7 @@ metadata:
 - `.kiro/specs/$1/tasks.md` (if exists, for merge mode)
 - Core steering context: `product.md`, `tech.md`, `structure.md`
 - Additional steering files only when directly relevant to requirements coverage, design boundaries, runtime prerequisites, or team conventions that affect task executability
+- `.kiro/settings/templates/specs/localized-spec-terminology.md` for localized spec terms
 
 **Validate approvals**:
 - If `-y` flag provided: Auto-approve requirements and design in spec.json. Tasks approval is also handled automatically in Step 4.
@@ -38,13 +39,13 @@ metadata:
 **Load generation rules and template**:
 - Read `rules/tasks-generation.md` from this skill's directory for principles
 - If `sequential` is false: Read `rules/tasks-parallel-analysis.md` from this skill's directory for parallel judgement criteria
-- Read `.kiro/settings/templates/specs/tasks.md` for format (supports `(P)` markers)
+- Select the matching tasks template from `spec.json.language`: `.kiro/settings/templates/specs/tasks.md` for `ja`, or `.kiro/settings/templates/specs/tasks.en.md` for `en`. Stop for unsupported languages. Both templates support `(P)` markers.
 
 #### Parallel Research
 
 The following research areas are independent and can be executed in parallel:
 1. **Context loading**: Spec documents (requirements.md, design.md), steering files
-2. **Rules loading**: tasks-generation.md, tasks-parallel-analysis.md, tasks template
+2. **Rules loading**: tasks-generation.md, tasks-parallel-analysis.md, localized spec terminology, tasks template
 
 If multi-agent is enabled, spawn sub-agents for each area above. Otherwise execute sequentially.
 
@@ -128,8 +129,8 @@ Before writing `tasks.md`, run one lightweight independent sanity review of the 
 
 ## Critical Constraints
 - **Task Integration**: Every task must connect to the system (no orphaned work)
-- **Boundary annotations**: Required for `(P)` tasks, recommended for all (`_Boundary: ComponentName_`)
-- **Explicit dependencies**: Cross-boundary non-obvious dependencies declared with `_Depends: X.X_`
+- **Boundary annotations**: Required for every executable task (`_Boundary:_ ComponentName`)
+- **Explicit dependencies**: Every executable task declares `_Depends:_ none` or a specific cross-boundary dependency such as `_Depends:_ X.X`
 - **Executable deliverable granularity**: Each task must produce a verifiable deliverable (file, endpoint, UI component, config). Infrastructure tasks (project scaffolding, manifest, host integration, build config) must be explicit — never assume they exist
 - **Observable done state**: Each executable sub-task must include at least one detail bullet that makes the completed state visible without adding new bookkeeping fields
 - **No implicit prerequisites**: If a task requires a runtime, SDK, framework setup, or config file, that setup must be a separate preceding task
@@ -179,8 +180,8 @@ Provide brief summary in the language specified in spec.json:
 - **Suggested Action**: "Refine requirements.md or design.md, then re-run `$kiro-spec-tasks $1`"
 
 **Template/Rules Missing**:
+- **Stop Execution**: The selected language-specific template and required rules files must exist
 - **User Message**: "Template or rules files missing in `.kiro/settings/`"
-- **Fallback**: Use inline basic structure with warning
 - **Suggested Action**: "Check repository setup or restore template files"
 - **Missing Numeric Requirement IDs**:
   - **Stop Execution**: All requirements in requirements.md MUST have numeric IDs. If any requirement lacks a numeric ID, stop and request that requirements.md be fixed before generating tasks.

--- a/.agents/skills/kiro-spec-tasks/rules/tasks-generation.md
+++ b/.agents/skills/kiro-spec-tasks/rules/tasks-generation.md
@@ -2,7 +2,28 @@
 
 ## Core Principles
 
-### 1. Natural Language Descriptions
+### 1. Language Compliance
+
+Generated `tasks.md` must use the language specified by `.kiro/specs/<feature>/spec.json`.
+
+**Must translate into the spec language**:
+- Document title and section headings
+- Major task titles
+- Sub-task titles
+- Detail bullets
+- Observable completion bullets
+- User-facing summaries and final responses
+
+**Keep unchanged when appropriate**:
+- Machine-readable labels: `_Requirements:_`, `_Boundary:_`, `_Depends:_`
+- Checkbox syntax, task numbers, `(P)`, and requirement IDs
+- Code identifiers, package names, API names, command names, and established domain terms
+
+**Template caveat**:
+- English text in templates and examples is structural guidance only.
+- Do not copy English phrases such as `Implementation Plan`, `Foundation`, `Build`, `Validate`, `Task Format Template`, or example task wording into generated `tasks.md` unless `spec.json.language` is English.
+
+### 2. Natural Language Descriptions
 Focus on capabilities and outcomes, not code structure.
 
 **Describe**:
@@ -21,58 +42,61 @@ Focus on capabilities and outcomes, not code structure.
 
 **Rationale**: Implementation details (files, methods, types) are defined in design.md. Tasks describe the functional work to be done.
 
-### 2. Task Ordering Principle
+### 3. Task Ordering Principle
 
 **Order implies dependency**: Task N implicitly depends on all tasks before it. This is the primary dependency mechanism.
 
-**Tasks must follow this phase order**:
-1. **Foundation**: Environment setup, test infrastructure, shared utilities, database schema, configuration
-2. **Core**: Primary feature implementation (parallel-capable tasks grouped here)
-3. **Integration**: Wiring components together, cross-boundary connections
-4. **Validation**: E2E tests, edge cases, regression checks
+**Tasks must follow this conceptual phase order**:
+1. Setup/foundation category: Environment setup, test infrastructure, shared utilities, database schema, configuration
+2. Primary feature category: Primary feature implementation (parallel-capable tasks grouped here)
+3. Integration category: Wiring components together, cross-boundary connections
+4. Validation category: E2E tests, edge cases, regression checks
 
-**Rationale**: Foundation work unblocks everything else. Placing setup tasks early prevents downstream blocking. Core tasks can often run in parallel because foundation is already complete.
+Localize visible major-task titles to the spec language. For example, Japanese specs should use Japanese titles such as `基盤`, `コア`, `統合`, and `検証`; English specs may use `Foundation`, `Core`, `Integration`, and `Validation`.
 
-### 3. Task Integration & Progression
+**Rationale**: Setup work unblocks everything else. Placing setup tasks early prevents downstream blocking. Primary feature tasks can often run in parallel because setup is already complete.
+
+### 4. Task Integration & Progression
 
 **Every task must**:
 - Build on previous outputs (no orphaned code)
 - Connect to the overall system (no hanging features)
 - Progress incrementally (no big jumps in complexity)
-- Respect architecture boundaries defined in design.md (Architecture Pattern & Boundary Map)
+- Respect architecture boundaries defined in design.md using the localized architecture boundary map subsection from `localized-spec-terminology.md`
 - Honor interface contracts documented in design.md
 - Use major task summaries sparingly—omit detail bullets if the work is fully captured by child tasks.
 
 **End with integration tasks** to wire everything together.
 
-### 4. Dependency Declaration
+### 5. Dependency Declaration
 
-**Default**: Sequential ordering handles most dependencies (task N depends on tasks before it).
+**Default**: Sequential ordering still handles most dependencies (task N depends on tasks before it), but every executable task must state the dependency field explicitly.
+Use `_Depends:_ none` when the task has no specific dependency beyond normal ordering.
 
 **Explicit declaration required when**:
 - A task depends on a specific task in a different major-task group (cross-boundary)
 - The dependency is non-obvious from ordering alone
 - A task can skip ahead of its position (declared via `(P)`) but still needs specific prior work
 
-**Format**: `_Depends: 1.2, 2.3_` — placed alongside `_Requirements:_` in task detail sections.
+**Format**: `_Depends:_ 1.2, 2.3` — placed alongside `_Requirements:_` in task detail sections.
 
-**Do not over-annotate**: If a task simply depends on the task directly before it, ordering alone is sufficient.
+**Do not over-annotate with IDs**: If a task simply depends on the task directly before it, use `_Depends:_ none`.
 
-### 5. Boundary Scope
+### 6. Boundary Scope
 
-**Each task should declare its component boundary** using design.md component/module names:
-- `_Boundary: AuthService_` or `_Boundary: API Layer, UserRepository_`
+**Each executable task must declare its component boundary** using design.md component/module names:
+- `_Boundary:_ AuthService` or `_Boundary:_ API Layer, UserRepository`
 - Helps validate parallel safety: tasks with non-overlapping boundaries are parallel candidates
 - Helps agents understand scope: what to touch and what not to touch
 
-**When to use**: Required for tasks marked `(P)` to validate parallel safety. Omit for sequential tasks where scope is obvious from the description.
+**When to use**: Required for every executable task. Keep it narrow for normal tasks and use an explicit integration boundary for cross-boundary integration tasks.
 
 **Boundary rule**:
 - Each executable task should stay within a single responsibility boundary
 - If work must cross boundaries, make it an explicit integration task rather than a normal implementation task
 - Do not hide cross-boundary coordination inside a task that appears local
 
-### 6. Flexible Task Sizing
+### 7. Flexible Task Sizing
 
 **Guidelines**:
 - **Major tasks**: As many sub-tasks as logically needed (group by cohesion)
@@ -81,14 +105,16 @@ Focus on capabilities and outcomes, not code structure.
 
 **Don't force arbitrary numbers** - let logical grouping determine structure.
 
-### 7. Requirements Mapping
+### 8. Requirements Mapping
 
 **End each task detail section with**:
-- `_Requirements: X.X, Y.Y_` listing **only numeric requirement IDs** (comma-separated). Never append descriptive text, parentheses, translations, or free-form labels.
+- `_Requirements:_ X.X, Y.Y` listing **only numeric requirement IDs** (comma-separated). Never append descriptive text, parentheses, translations, or free-form labels.
+- `_Boundary:_ ComponentName` using the narrowest design.md component/module boundary that owns the work.
+- `_Depends:_ none` when no specific dependency ID is needed, or `_Depends:_ X.Y, Z.W` when a specific dependency is required.
 - For cross-cutting requirements, list every relevant requirement ID. All requirements MUST have numeric IDs in requirements.md. If an ID is missing, stop and correct requirements.md before generating tasks.
 - Reference components/interfaces from design.md when helpful (e.g., `_Contracts: AuthService API`)
 
-### 7.5 Observable Completion
+### 8.5 Observable Completion
 
 **Each executable task must include at least one detail bullet that describes the observable completed state**:
 - Phrase it as a deliverable, runtime behavior, persisted state, UI state, endpoint behavior, test result, or integration outcome
@@ -96,7 +122,7 @@ Focus on capabilities and outcomes, not code structure.
 - Prefer making one detail bullet clearly answer: "What will be true when this task is done?"
 - Keep this within the existing task body; do not add extra bookkeeping fields
 
-### 8. Code-Only Focus
+### 9. Code-Only Focus
 
 **Include ONLY**:
 - Coding tasks (implementation)
@@ -125,12 +151,20 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
 - Every sub-task must be executable as written, usually within 1-3 hours.
 - Every sub-task must produce a verifiable deliverable (behavior, artifact, endpoint, UI state, config, migration, test, or integration result).
 - Every executable sub-task must include at least one detail bullet that states the observable completion condition.
+- Every executable sub-task must include `_Requirements:_`, `_Boundary:_`, and `_Depends:_` annotations. Use `_Depends:_ none` when the task has no explicit prerequisite.
 - Split tasks that combine multiple independently verifiable outcomes.
 - Split tasks that combine multiple responsibility boundaries unless they are explicit integration tasks.
 - If many tasks require broad `_Boundary:_` scopes or repeated cross-boundary coordination, stop and return to design or roadmap decomposition instead of forcing the spec through task generation.
 - Merge or collapse tasks that are too small, bookkeeping-only, or not meaningful execution units.
 - Make implicit prerequisites explicit as preceding tasks.
 - Re-check `_Depends:_`, `_Boundary:_`, and `(P)` markers after edits so concurrency claims still match the design boundaries and dependency graph.
+
+### Language Review
+
+- Verify generated natural-language content uses `spec.json.language`.
+- If the target language is not English, search for copied English template phrases and translate them before writing.
+- Do not translate machine-readable labels (`_Requirements:_`, `_Boundary:_`, `_Depends:_`), requirement IDs, task numbers, package names, code identifiers, or API names.
+- If a term is intentionally English because it is a code/API/domain identifier, leave it unchanged.
 
 ### Review Loop
 
@@ -167,11 +201,11 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
   - No shared file or resource contention
   - No prerequisite review/approval from another task
   - `_Boundary:_` annotations confirm non-overlapping component scopes
-- Foundation-phase tasks (see Task Ordering Principle) are rarely `(P)` — they establish shared prerequisites.
-- Core-phase tasks are the primary candidates for `(P)` since foundation is already complete.
-- Validate that identified parallel tasks operate within separate boundaries defined in the Architecture Pattern & Boundary Map.
+- Setup-category tasks (see Task Ordering Principle) are rarely `(P)` — they establish shared prerequisites.
+- Primary feature tasks are the main candidates for `(P)` since setup is already complete.
+- Validate that identified parallel tasks operate within separate boundaries defined in the localized architecture boundary map subsection.
 - Confirm API/event contracts from design.md do not overlap in ways that cause conflicts.
-- `(P)` tasks with cross-boundary dependencies must declare `_Depends: X.X_` explicitly.
+- `(P)` tasks with cross-boundary dependencies must declare `_Depends:_ X.X` explicitly.
 - Append `(P)` immediately after the task number for each parallel-capable task:
   - Example: `- [ ] 2.1 (P) Build background worker`
   - Apply to both major tasks and sub-tasks when appropriate.
@@ -181,32 +215,37 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
 
 ### Checkbox Format
 ```markdown
-- [ ] 1. Foundation: environment and test infrastructure setup
-- [ ] 1.1 Sub-task description
-  - Detail item 1
-  - Detail item 2
-  - Observable completion condition
-  - _Requirements: X.X_
+- [ ] 1. {{LOCALIZED_SETUP_PHASE_TITLE}}
+- [ ] 1.1 {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEM_1}}
+  - {{LOCALIZED_DETAIL_ITEM_2}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ X.X
+  - _Boundary:_ SharedSetup
+  - _Depends:_ none
 
-- [ ] 2. Core feature A
-- [ ] 2.1 (P) Sub-task description
-  - Detail items...
-  - Observable completion condition
-  - _Requirements: Y.Y_
-  - _Boundary: AuthService_
+- [ ] 2. {{LOCALIZED_PRIMARY_FEATURE_PHASE_TITLE}}
+- [ ] 2.1 (P) {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEMS}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ Y.Y
+  - _Boundary:_ AuthService
+  - _Depends:_ none
 
-- [ ] 2.2 (P) Sub-task description
-  - Detail items...
-  - Observable completion condition
-  - _Requirements: Z.Z_
-  - _Boundary: UserRepository_
+- [ ] 2.2 (P) {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEMS}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ Z.Z
+  - _Boundary:_ UserRepository
+  - _Depends:_ none
 
-- [ ] 3. Integration and wiring
-- [ ] 3.1 Sub-task description
-  - Detail items...
-  - Observable completion condition
-  - _Depends: 2.1, 2.2_
-  - _Requirements: W.W_
+- [ ] 3. {{LOCALIZED_INTEGRATION_PHASE_TITLE}}
+- [ ] 3.1 {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEMS}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ W.W
+  - _Boundary:_ {{INTEGRATION_BOUNDARY}}
+  - _Depends:_ 2.1, 2.2
 ```
 
 ## Requirements Coverage
@@ -217,6 +256,6 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
 - If gaps found: Return to requirements or design phase
 - No requirement should be left without corresponding tasks
 
-Use `N.M`-style numeric requirement IDs where `N` is the top-level requirement number from requirements.md (for example, Requirement 1 → 1.1, 1.2; Requirement 2 → 2.1, 2.2), and `M` is a local index within that requirement group.
+Use `N.M`-style numeric requirement IDs where `N` is the top-level requirement number from requirements.md, regardless of which requirement heading term from `.kiro/settings/templates/specs/localized-spec-terminology.md` the artifact uses.
 
 Document any intentionally deferred requirements with rationale.

--- a/.agents/skills/kiro-spec-tasks/rules/tasks-parallel-analysis.md
+++ b/.agents/skills/kiro-spec-tasks/rules/tasks-parallel-analysis.md
@@ -36,6 +36,6 @@ Before marking a task with `(P)`, ensure you have:
 - Confirmed `_Boundary:_` annotations show non-overlapping component scopes.
 - Captured any shared state expectations in the detail bullets.
 - Confirmed that the implementation can be tested independently.
-- Added `_Depends: X.X_` if this `(P)` task still requires specific prior work from a different major-task group.
+- Added `_Depends:_ X.X` if this `(P)` task still requires specific prior work from a different major-task group.
 
 If any check fails, **do not** mark the task with `(P)` and explain the dependency in the task details.

--- a/.agents/skills/kiro-validate-impl/SKILL.md
+++ b/.agents/skills/kiro-validate-impl/SKILL.md
@@ -11,7 +11,7 @@ Individual tasks have already been reviewed by the per-task reviewer during impl
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
-- design fixes `Boundary Commitments`
+- design fixes the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - tasks constrain execution with `_Boundary:_`
 - feature validation checks for cross-task `Boundary Violations`
 
@@ -68,6 +68,7 @@ For each detected feature:
 - Read `.kiro/specs/<feature>/requirements.md` for requirements
 - Read `.kiro/specs/<feature>/design.md` for design structure
 - Read `.kiro/specs/<feature>/tasks.md` for task list and Implementation Notes
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` and resolve language-specific section terms from `spec.json.language` before design boundary checks
 - Core steering context: `product.md`, `tech.md`, `structure.md`
 - Additional steering files only when directly relevant to the validated boundaries, runtime prerequisites, integrations, domain rules, security/performance constraints, or team conventions that affect the GO/NO-GO call
 
@@ -120,12 +121,12 @@ For each detected feature:
 - Verify the overall component graph matches design.md
 - Check that integration patterns (event flow, API boundaries, dependency injection) work as designed
 - Verify dependency direction follows design.md's architecture (no upward imports)
-- Verify File Structure Plan matches the actual file layout
+- Verify the file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` matches the actual file layout
 - Identify any architectural drift from the original design
 - Use the original section numbering from `design.md`
 
 **G.5 Boundary Audit**
-- Compare completed work against the design's `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers`
+- Compare completed work against the boundary terms named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - Identify cross-task spillover where one area quietly absorbed another boundary's responsibility
 - Identify downstream-specific workarounds embedded upstream "to make integration easier"
 - Identify new hidden dependencies or shared ownership that were not declared in the design
@@ -166,7 +167,7 @@ Provide summary in the language specified in spec.json:
 - DESIGN:
   - Architecture drift: <findings>
   - Dependency direction: <violations if any>
-  - File Structure Plan vs actual: <match/mismatch>
+  - File structure plan vs actual: <match/mismatch>
 - OWNERSHIP: LOCAL | UPSTREAM | UNCLEAR
 - UPSTREAM_SPEC: <feature-name | N/A>
 - BLOCKED_TASKS: <list and impact assessment>

--- a/.claude/skills/kiro-review/SKILL.md
+++ b/.claude/skills/kiro-review/SKILL.md
@@ -13,7 +13,7 @@ This skill performs task-local adversarial review. It verifies that the implemen
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
-- design fixes `Boundary Commitments`
+- design fixes the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - tasks constrain execution with `_Boundary:_`
 - review rejects concrete `Boundary Violations`
 
@@ -32,7 +32,8 @@ Provide:
 - Task ID and exact task text from `tasks.md`
 - Relevant requirement section numbers
 - Relevant design section numbers
-- Spec file paths (`requirements.md`, `design.md`, optionally `tasks.md`)
+- Spec file paths (`spec.json`, `requirements.md`, `design.md`, optionally `tasks.md`)
+- `.kiro/settings/templates/specs/localized-spec-terminology.md` for language-specific boundary terms
 - The implementer's status report
 - The task `_Boundary:_` scope constraints
 - Validation commands discovered by the controller
@@ -112,7 +113,7 @@ Run these checks and use the result as primary signal.
 - Reject silent substitutions for design-mandated choices.
 
 ### 10.5 Boundary Audit
-- Compare the implementation against the design's boundary commitments and out-of-boundary statements.
+- Compare the implementation against the design boundary and out-of-boundary terms named by `.kiro/settings/templates/specs/localized-spec-terminology.md`, using `spec.json.language` to select the artifact language.
 - Reject if downstream-specific behavior is pushed into an upstream boundary for convenience.
 - Reject if the implementation creates new hidden dependencies, shared ownership, or undeclared coupling across adjacent boundaries.
 - Reject if a task that is not an explicit integration task now behaves like one.

--- a/.claude/skills/kiro-spec-design/SKILL.md
+++ b/.claude/skills/kiro-spec-design/SKILL.md
@@ -4,6 +4,7 @@ description: Generate comprehensive technical design translating requirements (W
 allowed-tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent
 argument-hint: <feature-name> [-y]
 metadata:
+  cross-skill-rules: ".kiro/settings/templates/specs/localized-spec-terminology.md"
   shared-rules: "design-principles.md, design-discovery-full.md, design-discovery-light.md, design-synthesis.md, design-review-gate.md"
 ---
 
@@ -27,9 +28,10 @@ Otherwise, load all necessary context:
 - `.kiro/specs/{feature}/research.md` (if exists, contains gap analysis from `/kiro-validate-gap`)
 - Core steering context: `product.md`, `tech.md`, `structure.md`
 - Additional steering files only when directly relevant to requirement coverage, architecture boundaries, integrations, runtime prerequisites, security/performance constraints, or team conventions that affect implementation readiness
-- `.kiro/settings/templates/specs/design.md` for document structure
+- Select the matching design template from `spec.json.language`: `.kiro/settings/templates/specs/design.md` for `ja`, or `.kiro/settings/templates/specs/design.en.md` for `en`. Stop for missing or unsupported languages.
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` for localized spec terms
 - Read `rules/design-principles.md` from this skill's directory for design principles
-- `.kiro/settings/templates/specs/research.md` for discovery log structure
+- Select the matching research template from `spec.json.language`: `.kiro/settings/templates/specs/research.md` for `ja`, or `.kiro/settings/templates/specs/research.en.md` for `en`. Stop for unsupported languages.
 
 **Validate requirements approval**:
 - If auto-approve flag is true: Auto-approve requirements in spec.json
@@ -85,7 +87,7 @@ After all findings return, synthesize in main context before proceeding.
    - Boundary candidates, out-of-boundary decisions, and likely revalidation triggers
 
 4. **Persist Findings to Research Log**:
-   - Create or update `.kiro/specs/{feature}/research.md` using the shared template
+   - Create or update `.kiro/specs/{feature}/research.md` using the selected research template
    - Summarize discovery scope and key findings
    - Record investigations with sources and implications
    - Document architecture pattern evaluation, design decisions, and risks
@@ -102,10 +104,11 @@ After all findings return, synthesize in main context before proceeding.
 ### Step 4: Generate Design Draft
 
 1. **Generate Design Draft**:
-   - **Follow specs/design.md template structure and generation instructions strictly**
+   - Select the matching design template from `spec.json.language`: `.kiro/settings/templates/specs/design.md` for `ja`, or `.kiro/settings/templates/specs/design.en.md` for `en`. Stop for unsupported languages.
+   - **Follow the selected design template structure and generation instructions strictly**
    - **Boundary-first requirement**: Before expanding supporting sections, make the boundary explicit. The draft must clearly define what this spec owns, what it does not own, which dependencies are allowed, and what changes would require downstream revalidation.
    - **Integrate all discovery findings and synthesis outcomes**: Use researched information (APIs, patterns, technologies) and synthesis decisions (generalizations, build-vs-adopt, simplifications) throughout component definitions, architecture decisions, and integration points
-   - **File Structure Plan** (required): Populate the File Structure Plan section with concrete file paths and responsibilities. Analyze the codebase to determine which files need to be created vs. modified. Each file must have one clear responsibility. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs — vague file structures produce vague implementations.
+   - **File structure plan** (required): Populate the file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` with concrete file paths and responsibilities. Analyze the codebase to determine which files need to be created vs. modified. Each file must have one clear responsibility. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs — vague file structures produce vague implementations.
    - **Testing Strategy**: Derive test items from requirements' acceptance criteria, not generic patterns. Each test item should reference specific components and behaviors from this design. E2E paths must map to the critical user flows identified in requirements. Avoid vague entries like "test login works" -- instead specify what is being verified and why it matters.
    - If existing design.md found in Step 1, use it as reference context (merge mode)
    - Apply design rules: Type Safety, Visual Communication, Formal Tone
@@ -157,7 +160,7 @@ Provide brief summary in the language specified in spec.json:
 
 **Format**: Concise Markdown (under 200 words) - this is the command output, NOT the design document itself
 
-**Note**: The actual design document follows `.kiro/settings/templates/specs/design.md` structure.
+**Note**: The actual design document follows the selected design template structure for `spec.json.language`.
 
 ## Safety & Fallback
 
@@ -174,9 +177,9 @@ Provide brief summary in the language specified in spec.json:
 - **Suggested Action**: "Run `/kiro-spec-requirements {feature}` to generate requirements first"
 
 **Template Missing**:
-- **User Message**: "Template file missing at `.kiro/settings/templates/specs/design.md`"
+- **Stop Execution**: The selected language-specific design template, research template, and localized terminology file must exist
+- **User Message**: "Template file missing for selected spec language"
 - **Suggested Action**: "Check repository setup or restore template file"
-- **Fallback**: Use inline basic structure with warning
 
 **Steering Context Missing**:
 - **Warning**: "Steering directory empty or missing - design may not align with project standards"

--- a/.claude/skills/kiro-spec-design/rules/design-principles.md
+++ b/.claude/skills/kiro-spec-design/rules/design-principles.md
@@ -30,7 +30,7 @@
 ### 4. Component Design Rules
 - **Single Responsibility**: One clear purpose per component
 - **Clear Boundaries**: Explicit domain ownership
-- **Boundary Commitments First**: Before detailing components, state the responsibility boundary this design commits to
+- **Boundary Commitments First**: Before detailing components, state the responsibility boundary this design commits to using the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - **Dependency Direction**: Follow architectural layers
 - **Interface Segregation**: Minimal, focused interfaces
 - **Team-safe Interfaces**: Design boundaries that allow parallel implementation without merge conflicts
@@ -60,7 +60,7 @@
 - **Define and enforce the dependency direction** in the architecture section of design.md (e.g., Types → Config → Repository → Service → Runtime → UI)
 - Each layer imports only from layers to its left — never upward
 - This constraint is not a suggestion; implementation and review should treat violations as errors
-- When the File Structure Plan maps files to components, the dependency direction determines which imports are allowed
+- When the file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` maps files to components, the dependency direction determines which imports are allowed
 
 ## Documentation Standards
 
@@ -80,14 +80,14 @@
 ## Section Authoring Guidance
 
 ### Global Ordering
-- Default flow: Overview → Goals/Non-Goals → Boundary Commitments → Architecture → File Structure Plan → Components & Interfaces → Optional sections.
+- Follow the selected language-specific design template from `spec.json.language` (`design.md` for `ja`, `design.en.md` for `en`) and keep section headings intact for the artifact language.
 - Teams may swap Traceability earlier or place Data Models nearer Architecture when it improves clarity, but keep section headings intact.
 - Within each section, follow **Summary → Scope → Decisions → Impacts/Risks** so reviewers can scan consistently.
 
 ### Requirement IDs
 - Reference requirements as `2.1, 2.3` without prefixes (no “Requirement 2.1”).
 - All requirements MUST have numeric IDs. If a requirement lacks a numeric ID, stop and fix `requirements.md` before continuing.
-- Use `N.M`-style numeric IDs where `N` is the top-level requirement number from requirements.md (for example, Requirement 1 → 1.1, 1.2; Requirement 2 → 2.1, 2.2).
+- Use `N.M`-style numeric IDs where `N` is the top-level requirement number from requirements.md, regardless of whether the requirement heading uses the Japanese or English term from `.kiro/settings/templates/specs/localized-spec-terminology.md`.
 - Every component, task, and traceability row must reference the same canonical numeric ID.
 
 ### Technology Stack
@@ -102,14 +102,14 @@
   - **Data/Event** for pipelines or async patterns
 - Always use pure Mermaid. If no complex flow exists, omit the entire section.
 
-### Requirements Traceability
-- Use the standard table (`Requirement | Summary | Components | Interfaces | Flows`) to prove coverage.
+### Traceability Section
+- Use the table language that matches the artifact language to prove coverage.
 - Collapse to bullet form only when a single requirement maps 1:1 to a component.
 - Prefer the component summary table for simple mappings; reserve the full traceability table for complex or compliance-sensitive requirements.
 - Re-run this mapping whenever requirements or components change to avoid drift.
 
 ### Components & Interfaces Authoring
-- Boundary Commitments should already make the ownership seam explicit before this section begins.
+- The design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` should already make the ownership boundary explicit before this section begins.
 - Group components by domain/layer and provide one block per component.
 - Begin with a summary table listing Component, Domain, Intent, Requirement coverage, key dependencies, and selected contracts.
 - Table fields: Intent (one line), Requirements (`2.1, 2.3`), Owner/Reviewers (optional).

--- a/.claude/skills/kiro-spec-design/rules/design-review-gate.md
+++ b/.claude/skills/kiro-spec-design/rules/design-review-gate.md
@@ -36,11 +36,12 @@ Before writing `design.md`, review the draft design and repair local issues unti
 ## Mechanical Checks
 
 Before applying judgment, verify these mechanically:
-- **Requirements traceability**: Extract all numeric requirement IDs from `requirements.md`. Scan the design draft for each ID. Report any IDs not found in the design.
-- **Boundary section populated**: `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers` must not be empty or placeholder-only.
-- **File Structure Plan populated**: The File Structure Plan section must contain concrete file paths (not just "TBD" or empty). Scan for placeholder text in that section.
-- **Boundary ↔ file structure alignment**: The File Structure Plan must reflect the stated responsibility boundary. If files imply broader ownership than the boundary section claims, report a mismatch.
-- **No orphan components**: Every component mentioned in the design must appear in the File Structure Plan with a file path. Scan for component names that have no corresponding file entry.
+- **Artifact language selected**: Read `spec.json.language` before section-name checks. Use the matching Japanese or English terms from `.kiro/settings/templates/specs/localized-spec-terminology.md`. If the language is missing or unsupported, or the localized terminology file is missing, stop and clarify the target language or repository setup before applying this gate.
+- **Requirements traceability**: Extract all numeric requirement IDs from `requirements.md` using the requirement heading form for `spec.json.language` from `.kiro/settings/templates/specs/localized-spec-terminology.md`; also accept existing hybrid headings that use the alternate Japanese/English heading term and existing numeric requirement list items. Scan the design draft for each ID. Report any IDs not found in the design.
+- **Boundary section populated**: The design boundary section and boundary subsections named by `.kiro/settings/templates/specs/localized-spec-terminology.md` must not be empty or placeholder-only. Also accept existing hybrid headings that use the alternate Japanese/English heading terms from the same terminology row.
+- **File structure section populated**: The file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` must contain concrete file paths (not just "TBD" or empty). Also accept the alternate Japanese/English file structure heading from the same terminology row. Scan for placeholder text in that section.
+- **Boundary ↔ file structure alignment**: The file structure section must reflect the stated responsibility boundary. If files imply broader ownership than the boundary section claims, report a mismatch.
+- **No orphan components**: Every component mentioned in the design must appear in the file structure section with a file path. Scan for component names that have no corresponding file entry.
 
 ## Review Loop
 

--- a/.claude/skills/kiro-spec-init/SKILL.md
+++ b/.claude/skills/kiro-spec-init/SKILL.md
@@ -18,12 +18,14 @@ Generate a unique feature name from the project description ($ARGUMENTS) and ini
 4. **Create Directory**: `.kiro/specs/[feature-name]/` (skip if already exists from discovery)
 5. **Initialize Files Using Templates**:
    - Read `.kiro/settings/templates/specs/init.json`
-   - Read `.kiro/settings/templates/specs/requirements-init.md`
+   - Detect the language code from the selected project description source: use brief.md content when present, otherwise use the user's input language. If uncertain, select `ja` as the repository default.
+   - Select the matching requirements skeleton: `.kiro/settings/templates/specs/requirements-init.md` for `ja`, or `.kiro/settings/templates/specs/requirements-init.en.md` for `en`. Stop for unsupported languages.
    - Replace placeholders:
      - `{{FEATURE_NAME}}` → generated feature name
      - `{{TIMESTAMP}}` → current ISO 8601 timestamp
      - `{{PROJECT_DESCRIPTION}}` → from brief.md if available, otherwise $ARGUMENTS
-     - `ja` → language code (detect from user's input language, default to `en`)
+     - `{{LANGUAGE}}` → selected language code
+   - Ensure the selected language code and requirements skeleton language match before writing files
    - Write `spec.json` and `requirements.md` to spec directory
 
 ## Important Constraints
@@ -47,5 +49,6 @@ Provide output in the language specified in `spec.json` with the following struc
 ## Safety & Fallback
 - **Ambiguous Feature Name**: If feature name generation is unclear, propose 2-3 options and ask user to select
 - **Template Missing**: If template files don't exist in `.kiro/settings/templates/specs/`, report error with specific missing file path and suggest checking repository setup
+- **Unsupported Language**: If language detection selects a code without a requirements skeleton, stop and report the unsupported language instead of mixing metadata and template languages
 - **Directory Conflict**: If feature name already exists, append numeric suffix (e.g., `feature-name-2`) and notify user of automatic conflict resolution
 - **Write Failure**: Report error with specific path and suggest checking permissions or disk space

--- a/.claude/skills/kiro-spec-quick/SKILL.md
+++ b/.claude/skills/kiro-spec-quick/SKILL.md
@@ -72,21 +72,28 @@ Execute these 4 phases in order:
 
 5. **Initialize Files from Templates**:
 
-   a. Read templates:
+   a. Select language:
+   ```
+   selected language code → detect from the selected project description source: use brief.md content when present, otherwise use user's input language; if uncertain, select `ja` as the repository default
+   ```
+   Stop for unsupported languages. Use this same selected language code for `spec.json` and the requirements skeleton.
+
+   b. Read templates:
    ```
    - .kiro/settings/templates/specs/init.json
-   - .kiro/settings/templates/specs/requirements-init.md
+   - .kiro/settings/templates/specs/requirements-init.md for `ja`, or .kiro/settings/templates/specs/requirements-init.en.md for `en`
    ```
 
-   b. Replace placeholders:
+   c. Replace placeholders:
    ```
    {{FEATURE_NAME}} → feature-name
    {{TIMESTAMP}} → current ISO 8601 timestamp (use `date -u +"%Y-%m-%dT%H:%M:%SZ"`)
    {{PROJECT_DESCRIPTION}} → description
-   ja → language code (detect from user's input language, default to `en`)
+   {{LANGUAGE}} → selected language code
    ```
+   Ensure the selected language code and requirements skeleton language match before writing files.
 
-   c. Write files using Write tool:
+   d. Write files using Write tool:
    ```
    - .kiro/specs/{feature-name}/spec.json
    - .kiro/specs/{feature-name}/requirements.md

--- a/.claude/skills/kiro-spec-requirements/SKILL.md
+++ b/.claude/skills/kiro-spec-requirements/SKILL.md
@@ -32,7 +32,8 @@ Otherwise, load all necessary context:
 ### Step 2: Read Guidelines
 - Read `rules/ears-format.md` from this skill's directory for EARS syntax rules
 - Read `rules/requirements-review-gate.md` from this skill's directory for pre-write review criteria
-- Read `.kiro/settings/templates/specs/requirements.md` for document structure
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` for localized spec terms
+- Select the matching requirements template from `spec.json.language`: `.kiro/settings/templates/specs/requirements.md` for `ja`, or `.kiro/settings/templates/specs/requirements.en.md` for `en`. Stop for unsupported languages.
 
 #### Parallel Research (subagent dispatch)
 
@@ -55,7 +56,7 @@ After all research completes, synthesize findings in main context before generat
 - Preserve terminology continuity across phases:
   - discovery = `Boundary Candidates`
   - requirements = explicit inclusion/exclusion and adjacent expectations when needed
-  - design = `Boundary Commitments`
+  - design = design boundary section from `.kiro/settings/templates/specs/localized-spec-terminology.md`
   - tasks = `_Boundary:_`
 - If scope could be misread, add lightweight boundary context without introducing implementation or architecture ownership detail
 - Keep this as a draft until the review gate passes; do not write `requirements.md` yet
@@ -97,7 +98,7 @@ Requirements describe user-observable behavior, not implementation. Use this to 
 ### Other Constraints
 - Each requirement must be testable and unambiguous. If the project description leaves room for multiple interpretations on scope, behavior, or boundary conditions, ask the user to clarify before generating that requirement. Ask as many questions as needed; do not generate requirements that contain your own assumptions.
 - Choose appropriate subject for EARS statements (system/service name for software)
-- Requirement headings in requirements.md MUST include a leading numeric ID only (for example: "Requirement 1", "1.", "2 Feature ..."); do not use alphabetic IDs like "Requirement A".
+- Requirement headings in requirements.md MUST include a leading numeric ID only. New or rewritten headings should use the form for `spec.json.language` from `.kiro/settings/templates/specs/localized-spec-terminology.md`; existing hybrid headings using the alternate Japanese/English term remain valid if the numeric ID is present. Do not use alphabetic IDs like "要件 A" or "Requirement A".
 
 ## Output Description
 Provide output in the language specified in spec.json with:
@@ -116,11 +117,11 @@ Provide output in the language specified in spec.json with:
 
 ### Error Scenarios
 - **Missing Project Description**: If requirements.md lacks project description, ask user for feature details
-- **Template Missing**: If template files don't exist, use inline fallback structure with warning
-- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+- **Template Missing**: Stop if the selected language-specific requirements template or localized terminology file is missing
+- **Language Undefined**: Stop and clarify the target language if `spec.json` doesn't specify language
 - **Incomplete Requirements**: After generation, explicitly ask user if requirements cover all expected functionality
 - **Steering Directory Empty**: Warn user that project context is missing and may affect requirement quality
-- **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
+- **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "要件 A" or "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
 
 ### Next Phase: Design Generation
 

--- a/.claude/skills/kiro-spec-requirements/rules/ears-format.md
+++ b/.claude/skills/kiro-spec-requirements/rules/ears-format.md
@@ -1,49 +1,66 @@
 # EARS Format Guidelines
 
 ## Overview
+
 EARS (Easy Approach to Requirements Syntax) is the standard format for acceptance criteria in spec-driven development.
 
-EARS patterns describe the logical structure of a requirement (condition + subject + response) and are not tied to any particular natural language.  
-All acceptance criteria should be written in the target language configured for the specification (for example, `spec.json.language` / `ja`).  
-Keep EARS trigger keywords and fixed phrases in English (`When`, `If`, `While`, `Where`, `The system shall`, `The [system] shall`) and localize only the variable parts (`[event]`, `[precondition]`, `[trigger]`, `[feature is included]`, `[response/action]`) into the target language. Do not interleave target-language text inside the trigger or fixed English phrases themselves.
+EARS patterns describe the logical structure of a requirement: condition, subject, and response.
+They are not tied to English wording.
+All acceptance criteria should be written in the target language configured for the specification, such as `spec.json.language`.
+
+For Japanese specifications (`language: "ja"`), use Japanese EARS fixed phrases.
+Do not force English trigger words such as `When`, `If`, `While`, `Where`, or `shall` into Japanese requirements.
+Existing hybrid Japanese specs with English EARS triggers remain valid for review, but new or rewritten Japanese criteria should use the Japanese phrases.
 
 ## Primary EARS Patterns
 
 ### 1. Event-Driven Requirements
-- **Pattern**: When [event], the [system] shall [response/action]
+- **English Pattern**: When [event], the [system] shall [response/action]
+- **Japanese Pattern**: [イベント] が起きたとき、[システム] は [応答] しなければならない
 - **Use Case**: Responses to specific events or triggers
-- **Example**: When user clicks checkout button, the Checkout Service shall validate cart contents
+- **Example**: ユーザーがチェックアウトボタンをクリックしたとき、Checkout Service はカート内容を検証しなければならない
 
 ### 2. State-Driven Requirements
-- **Pattern**: While [precondition], the [system] shall [response/action]
+- **English Pattern**: While [precondition], the [system] shall [response/action]
+- **Japanese Pattern**: [前提] の間、[システム] は [応答] し続けなければならない
 - **Use Case**: Behavior dependent on system state or preconditions
-- **Example**: While payment is processing, the Checkout Service shall display loading indicator
+- **Example**: 支払い処理中の間、Checkout Service はローディング状態を表示し続けなければならない
 
 ### 3. Unwanted Behavior Requirements
-- **Pattern**: If [trigger], the [system] shall [response/action]
+- **English Pattern**: If [trigger], the [system] shall [response/action]
+- **Japanese Pattern**: [条件/異常] の場合、[システム] は [応答] しなければならない
 - **Use Case**: System response to errors, failures, or undesired situations
-- **Example**: If invalid credit card number is entered, then the website shall display error message
+- **Example**: 無効なカード番号が入力された場合、Checkout Service はエラーメッセージを表示しなければならない
 
 ### 4. Optional Feature Requirements
-- **Pattern**: Where [feature is included], the [system] shall [response/action]
+- **English Pattern**: Where [feature is included], the [system] shall [response/action]
+- **Japanese Pattern**: [機能/オプション] を含む場合、[システム] は [応答] しなければならない
 - **Use Case**: Requirements for optional or conditional features
-- **Example**: Where the car has a sunroof, the car shall have a sunroof control panel
+- **Example**: クーポン機能を含む場合、Checkout Service は割引額を注文合計に反映しなければならない
 
 ### 5. Ubiquitous Requirements
-- **Pattern**: The [system] shall [response/action]
+- **English Pattern**: The [system] shall [response/action]
+- **Japanese Pattern**: [システム] は常に [応答] しなければならない
 - **Use Case**: Always-active requirements and fundamental system properties
-- **Example**: The mobile phone shall have a mass of less than 100 grams
+- **Example**: Checkout Service は常に注文合計を税込金額で表示しなければならない
 
 ## Combined Patterns
-- While [precondition], when [event], the [system] shall [response/action]
-- When [event] and [additional condition], the [system] shall [response/action]
+
+- **English Pattern**: While [precondition], when [event], the [system] shall [response/action]
+- **English Pattern**: When [event] and [additional condition], the [system] shall [response/action]
+- [前提] の間、[イベント] が起きたとき、[システム] は [応答] しなければならない
+- [イベント] が起き、かつ [追加条件] の場合、[システム] は [応答] しなければならない
 
 ## Subject Selection Guidelines
-- **Software Projects**: Use concrete system/service name (e.g., "Checkout Service", "User Auth Module")
-- **Process/Workflow**: Use responsible team/role (e.g., "Support Team", "Review Process")
-- **Non-Software**: Use appropriate subject (e.g., "Marketing Campaign", "Documentation")
+
+- **Software Projects**: Use concrete system/service name, such as `Calendar Sync MVP`.
+- **Process/Workflow**: Use responsible team/role, such as `Support Team`.
+- **Non-Software**: Use appropriate subject, such as `Marketing Campaign`.
 
 ## Quality Criteria
+
 - Requirements must be testable, verifiable, and describe a single behavior.
-- Use objective language: "shall" for mandatory behavior, "should" for recommendations; avoid ambiguous terms.
-- Follow EARS syntax: [condition], the [system] shall [response/action].
+- Use objective mandatory language: in English, use `shall` for mandatory behavior; in Japanese, prefer `しなければならない`.
+- Avoid vague words such as `appropriate`, `where possible`, `適切に`, `できるだけ`, or `なるべく`.
+- Follow an EARS logical pattern even when localized into Japanese.
+- Keep implementation details out of requirements unless they are directly user- or operator-observable constraints.

--- a/.claude/skills/kiro-spec-requirements/rules/requirements-review-gate.md
+++ b/.claude/skills/kiro-spec-requirements/rules/requirements-review-gate.md
@@ -8,7 +8,7 @@ Use boundary terminology consistently across phases without turning requirements
 
 - **Discovery** identifies `Boundary Candidates`
 - **Requirements** make inclusion, exclusion, and adjacent expectations explicit when scope could be misread
-- **Design** turns those into `Boundary Commitments`
+- **Design** turns those into the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - **Tasks** use `_Boundary:_` to constrain executable work
 
 Requirements should clarify the feature boundary in user- or operator-observable terms, not in architecture ownership or implementation detail.
@@ -26,7 +26,7 @@ Requirements should clarify the feature boundary in user- or operator-observable
 - Every acceptance criterion must follow the EARS rules defined in `ears-format.md`.
 - Every requirement must be testable, observable, and specific enough that later design and validation can verify it.
 - Remove implementation details that belong in `design.md` rather than `requirements.md`.
-- Requirement headings must use numeric IDs only; do not mix numeric and alphabetic labels.
+- Requirement headings must use numeric IDs only. Prefer the heading form for `spec.json.language` from `.kiro/settings/templates/specs/localized-spec-terminology.md`; also accept existing hybrid headings that use the alternate Japanese/English heading term with a numeric ID. Do not mix numeric and alphabetic labels.
 
 ## Structure and Quality Review
 
@@ -40,7 +40,7 @@ Requirements should clarify the feature boundary in user- or operator-observable
 
 Before applying judgment, verify these mechanically:
 - **Numeric IDs present**: Every requirement heading has a numeric ID (1, 1.1, 2, etc.). Scan the draft for headings without IDs.
-- **Acceptance criteria exist**: Every requirement has at least one EARS-format acceptance criterion. Scan for requirements with no "When/If/While/Where" acceptance statements.
+- **Acceptance criteria exist**: Every requirement has at least one EARS-format acceptance criterion. Read `spec.json.language` first and choose the matching scan. For `language: "en"`, scan for conditional EARS trigger words such as "When", "If", "While", or "Where", and verify ubiquitous criteria by mandatory `shall` wording so named subjects such as service names are accepted. For `language: "ja"`, prefer localized EARS fixed phrases such as "が起きたとき", "の場合", "の間", "を含む場合", or "は常に", and verify the criterion also uses mandatory wording such as "しなければならない" or state-continuation wording such as "し続けなければならない"; also accept existing hybrid criteria that use English EARS trigger words and mandatory `shall` wording. If the language is missing or unsupported, stop and clarify the target language before applying this gate.
 - **No implementation language**: Scan for technology-specific terms (database names, framework names, API patterns) that belong in design, not requirements. Flag any found.
 
 ## Review Loop

--- a/.claude/skills/kiro-spec-status/SKILL.md
+++ b/.claude/skills/kiro-spec-status/SKILL.md
@@ -22,6 +22,7 @@ argument-hint: <feature-name>
 - Read existing files: `requirements.md`, `design.md`, `tasks.md` (if they exist)
 - Check `.kiro/specs/$ARGUMENTS/` directory for available files
 - Read `.kiro/steering/roadmap.md` if it exists and this spec appears in it
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` and select section names from `spec.json.language`; stop if the language is missing or unsupported
 
 ### Step 2: Analyze Status
 
@@ -32,7 +33,7 @@ argument-hint: <feature-name>
 - **Approvals**: Check approval status in spec.json
 - **Boundary context**:
   - From brief.md: note `Boundary Candidates`, `Upstream / Downstream`, and `Existing Spec Touchpoints` if present
-  - From design.md: note `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers` if present
+  - From design.md: note boundary terms using the selected localized terminology for this spec
   - From roadmap.md: note upstream dependencies and whether this spec is adjacent to `Existing Spec Updates`
 - **Revalidation watchlist**:
   - Identify downstream specs, neighboring existing-spec updates, or rollout-sensitive design notes that may need revalidation if this spec changes

--- a/.claude/skills/kiro-spec-tasks/SKILL.md
+++ b/.claude/skills/kiro-spec-tasks/SKILL.md
@@ -27,6 +27,7 @@ Otherwise, load all necessary context:
 - `.kiro/specs/{feature}/tasks.md` (if exists, for merge mode)
 - Core steering context: `product.md`, `tech.md`, `structure.md`
 - Additional steering files only when directly relevant to requirements coverage, design boundaries, runtime prerequisites, or team conventions that affect task executability
+- `.kiro/settings/templates/specs/localized-spec-terminology.md` for localized spec terms
 
 - Determine execution mode:
   - `sequential = (sequential flag is true)`
@@ -39,13 +40,13 @@ Otherwise, load all necessary context:
 
 - Read `rules/tasks-generation.md` from this skill's directory for principles
 - Read `rules/tasks-parallel-analysis.md` from this skill's directory for parallel judgement criteria
-- Read `.kiro/settings/templates/specs/tasks.md` for format (supports `(P)` markers)
+- Select the matching tasks template from `spec.json.language`: `.kiro/settings/templates/specs/tasks.md` for `ja`, or `.kiro/settings/templates/specs/tasks.en.md` for `en`. Stop for unsupported languages. Both templates support `(P)` markers.
 
 #### Parallel Research
 
 The following research areas are independent and can be executed in parallel:
 1. **Context loading**: Spec documents (requirements.md, design.md), steering files
-2. **Rules loading**: tasks-generation.md, tasks-parallel-analysis.md, tasks template
+2. **Rules loading**: tasks-generation.md, tasks-parallel-analysis.md, localized spec terminology, tasks template
 
 After all parallel research completes, synthesize findings before generating tasks.
 
@@ -126,8 +127,8 @@ Before writing `tasks.md`, run one lightweight independent sanity review of the 
 
 ## Critical Constraints
 - **Task Integration**: Every task must connect to the system (no orphaned work)
-- **Boundary annotations**: Required for `(P)` tasks, recommended for all (`_Boundary: ComponentName_`)
-- **Explicit dependencies**: Cross-boundary non-obvious dependencies declared with `_Depends: X.X_`
+- **Boundary annotations**: Required for every executable task (`_Boundary:_ ComponentName`)
+- **Explicit dependencies**: Every executable task declares `_Depends:_ none` or a specific cross-boundary dependency such as `_Depends:_ X.X`
 - **Executable deliverable granularity**: Each task must produce a verifiable deliverable (file, endpoint, UI component, config). Infrastructure tasks (project scaffolding, manifest, host integration, build config) must be explicit — never assume they exist
 - **Observable done state**: Each executable sub-task must include at least one detail bullet that makes the completed state visible without adding new bookkeeping fields
 - **No implicit prerequisites**: If a task requires a runtime, SDK, framework setup, or config file, that setup must be a separate preceding task
@@ -176,8 +177,8 @@ Provide brief summary in the language specified in spec.json:
 - **Suggested Action**: "Refine requirements.md or design.md, then re-run `/kiro-spec-tasks {feature}`"
 
 **Template/Rules Missing**:
+- **Stop Execution**: The selected language-specific template and required rules files must exist
 - **User Message**: "Template or rules files missing in `.kiro/settings/`"
-- **Fallback**: Use inline basic structure with warning
 - **Suggested Action**: "Check repository setup or restore template files"
 - **Missing Numeric Requirement IDs**:
   - **Stop Execution**: All requirements in requirements.md MUST have numeric IDs. If any requirement lacks a numeric ID, stop and request that requirements.md be fixed before generating tasks.

--- a/.claude/skills/kiro-spec-tasks/rules/tasks-generation.md
+++ b/.claude/skills/kiro-spec-tasks/rules/tasks-generation.md
@@ -2,7 +2,28 @@
 
 ## Core Principles
 
-### 1. Natural Language Descriptions
+### 1. Language Compliance
+
+Generated `tasks.md` must use the language specified by `.kiro/specs/<feature>/spec.json`.
+
+**Must translate into the spec language**:
+- Document title and section headings
+- Major task titles
+- Sub-task titles
+- Detail bullets
+- Observable completion bullets
+- User-facing summaries and final responses
+
+**Keep unchanged when appropriate**:
+- Machine-readable labels: `_Requirements:_`, `_Boundary:_`, `_Depends:_`
+- Checkbox syntax, task numbers, `(P)`, and requirement IDs
+- Code identifiers, package names, API names, command names, and established domain terms
+
+**Template caveat**:
+- English text in templates and examples is structural guidance only.
+- Do not copy English phrases such as `Implementation Plan`, `Foundation`, `Build`, `Validate`, `Task Format Template`, or example task wording into generated `tasks.md` unless `spec.json.language` is English.
+
+### 2. Natural Language Descriptions
 Focus on capabilities and outcomes, not code structure.
 
 **Describe**:
@@ -21,58 +42,61 @@ Focus on capabilities and outcomes, not code structure.
 
 **Rationale**: Implementation details (files, methods, types) are defined in design.md. Tasks describe the functional work to be done.
 
-### 2. Task Ordering Principle
+### 3. Task Ordering Principle
 
 **Order implies dependency**: Task N implicitly depends on all tasks before it. This is the primary dependency mechanism.
 
-**Tasks must follow this phase order**:
-1. **Foundation**: Environment setup, test infrastructure, shared utilities, database schema, configuration
-2. **Core**: Primary feature implementation (parallel-capable tasks grouped here)
-3. **Integration**: Wiring components together, cross-boundary connections
-4. **Validation**: E2E tests, edge cases, regression checks
+**Tasks must follow this conceptual phase order**:
+1. Setup/foundation category: Environment setup, test infrastructure, shared utilities, database schema, configuration
+2. Primary feature category: Primary feature implementation (parallel-capable tasks grouped here)
+3. Integration category: Wiring components together, cross-boundary connections
+4. Validation category: E2E tests, edge cases, regression checks
 
-**Rationale**: Foundation work unblocks everything else. Placing setup tasks early prevents downstream blocking. Core tasks can often run in parallel because foundation is already complete.
+Localize visible major-task titles to the spec language. For example, Japanese specs should use Japanese titles such as `基盤`, `コア`, `統合`, and `検証`; English specs may use `Foundation`, `Core`, `Integration`, and `Validation`.
 
-### 3. Task Integration & Progression
+**Rationale**: Setup work unblocks everything else. Placing setup tasks early prevents downstream blocking. Primary feature tasks can often run in parallel because setup is already complete.
+
+### 4. Task Integration & Progression
 
 **Every task must**:
 - Build on previous outputs (no orphaned code)
 - Connect to the overall system (no hanging features)
 - Progress incrementally (no big jumps in complexity)
-- Respect architecture boundaries defined in design.md (Architecture Pattern & Boundary Map)
+- Respect architecture boundaries defined in design.md using the localized architecture boundary map subsection from `localized-spec-terminology.md`
 - Honor interface contracts documented in design.md
 - Use major task summaries sparingly—omit detail bullets if the work is fully captured by child tasks.
 
 **End with integration tasks** to wire everything together.
 
-### 4. Dependency Declaration
+### 5. Dependency Declaration
 
-**Default**: Sequential ordering handles most dependencies (task N depends on tasks before it).
+**Default**: Sequential ordering still handles most dependencies (task N depends on tasks before it), but every executable task must state the dependency field explicitly.
+Use `_Depends:_ none` when the task has no specific dependency beyond normal ordering.
 
 **Explicit declaration required when**:
 - A task depends on a specific task in a different major-task group (cross-boundary)
 - The dependency is non-obvious from ordering alone
 - A task can skip ahead of its position (declared via `(P)`) but still needs specific prior work
 
-**Format**: `_Depends: 1.2, 2.3_` — placed alongside `_Requirements:_` in task detail sections.
+**Format**: `_Depends:_ 1.2, 2.3` — placed alongside `_Requirements:_` in task detail sections.
 
-**Do not over-annotate**: If a task simply depends on the task directly before it, ordering alone is sufficient.
+**Do not over-annotate with IDs**: If a task simply depends on the task directly before it, use `_Depends:_ none`.
 
-### 5. Boundary Scope
+### 6. Boundary Scope
 
-**Each task should declare its component boundary** using design.md component/module names:
-- `_Boundary: AuthService_` or `_Boundary: API Layer, UserRepository_`
+**Each executable task must declare its component boundary** using design.md component/module names:
+- `_Boundary:_ AuthService` or `_Boundary:_ API Layer, UserRepository`
 - Helps validate parallel safety: tasks with non-overlapping boundaries are parallel candidates
 - Helps agents understand scope: what to touch and what not to touch
 
-**When to use**: Required for tasks marked `(P)` to validate parallel safety. Omit for sequential tasks where scope is obvious from the description.
+**When to use**: Required for every executable task. Keep it narrow for normal tasks and use an explicit integration boundary for cross-boundary integration tasks.
 
 **Boundary rule**:
 - Each executable task should stay within a single responsibility boundary
 - If work must cross boundaries, make it an explicit integration task rather than a normal implementation task
 - Do not hide cross-boundary coordination inside a task that appears local
 
-### 6. Flexible Task Sizing
+### 7. Flexible Task Sizing
 
 **Guidelines**:
 - **Major tasks**: As many sub-tasks as logically needed (group by cohesion)
@@ -81,14 +105,16 @@ Focus on capabilities and outcomes, not code structure.
 
 **Don't force arbitrary numbers** - let logical grouping determine structure.
 
-### 7. Requirements Mapping
+### 8. Requirements Mapping
 
 **End each task detail section with**:
-- `_Requirements: X.X, Y.Y_` listing **only numeric requirement IDs** (comma-separated). Never append descriptive text, parentheses, translations, or free-form labels.
+- `_Requirements:_ X.X, Y.Y` listing **only numeric requirement IDs** (comma-separated). Never append descriptive text, parentheses, translations, or free-form labels.
+- `_Boundary:_ ComponentName` using the narrowest design.md component/module boundary that owns the work.
+- `_Depends:_ none` when no specific dependency ID is needed, or `_Depends:_ X.Y, Z.W` when a specific dependency is required.
 - For cross-cutting requirements, list every relevant requirement ID. All requirements MUST have numeric IDs in requirements.md. If an ID is missing, stop and correct requirements.md before generating tasks.
 - Reference components/interfaces from design.md when helpful (e.g., `_Contracts: AuthService API`)
 
-### 7.5 Observable Completion
+### 8.5 Observable Completion
 
 **Each executable task must include at least one detail bullet that describes the observable completed state**:
 - Phrase it as a deliverable, runtime behavior, persisted state, UI state, endpoint behavior, test result, or integration outcome
@@ -96,7 +122,7 @@ Focus on capabilities and outcomes, not code structure.
 - Prefer making one detail bullet clearly answer: "What will be true when this task is done?"
 - Keep this within the existing task body; do not add extra bookkeeping fields
 
-### 8. Code-Only Focus
+### 9. Code-Only Focus
 
 **Include ONLY**:
 - Coding tasks (implementation)
@@ -125,12 +151,20 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
 - Every sub-task must be executable as written, usually within 1-3 hours.
 - Every sub-task must produce a verifiable deliverable (behavior, artifact, endpoint, UI state, config, migration, test, or integration result).
 - Every executable sub-task must include at least one detail bullet that states the observable completion condition.
+- Every executable sub-task must include `_Requirements:_`, `_Boundary:_`, and `_Depends:_` annotations. Use `_Depends:_ none` when the task has no explicit prerequisite.
 - Split tasks that combine multiple independently verifiable outcomes.
 - Split tasks that combine multiple responsibility boundaries unless they are explicit integration tasks.
 - If many tasks require broad `_Boundary:_` scopes or repeated cross-boundary coordination, stop and return to design or roadmap decomposition instead of forcing the spec through task generation.
 - Merge or collapse tasks that are too small, bookkeeping-only, or not meaningful execution units.
 - Make implicit prerequisites explicit as preceding tasks.
 - Re-check `_Depends:_`, `_Boundary:_`, and `(P)` markers after edits so concurrency claims still match the design boundaries and dependency graph.
+
+### Language Review
+
+- Verify generated natural-language content uses `spec.json.language`.
+- If the target language is not English, search for copied English template phrases and translate them before writing.
+- Do not translate machine-readable labels (`_Requirements:_`, `_Boundary:_`, `_Depends:_`), requirement IDs, task numbers, package names, code identifiers, or API names.
+- If a term is intentionally English because it is a code/API/domain identifier, leave it unchanged.
 
 ### Review Loop
 
@@ -167,11 +201,11 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
   - No shared file or resource contention
   - No prerequisite review/approval from another task
   - `_Boundary:_` annotations confirm non-overlapping component scopes
-- Foundation-phase tasks (see Task Ordering Principle) are rarely `(P)` — they establish shared prerequisites.
-- Core-phase tasks are the primary candidates for `(P)` since foundation is already complete.
-- Validate that identified parallel tasks operate within separate boundaries defined in the Architecture Pattern & Boundary Map.
+- Setup-category tasks (see Task Ordering Principle) are rarely `(P)` — they establish shared prerequisites.
+- Primary feature tasks are the main candidates for `(P)` since setup is already complete.
+- Validate that identified parallel tasks operate within separate boundaries defined in the localized architecture boundary map subsection.
 - Confirm API/event contracts from design.md do not overlap in ways that cause conflicts.
-- `(P)` tasks with cross-boundary dependencies must declare `_Depends: X.X_` explicitly.
+- `(P)` tasks with cross-boundary dependencies must declare `_Depends:_ X.X` explicitly.
 - Append `(P)` immediately after the task number for each parallel-capable task:
   - Example: `- [ ] 2.1 (P) Build background worker`
   - Apply to both major tasks and sub-tasks when appropriate.
@@ -181,32 +215,37 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
 
 ### Checkbox Format
 ```markdown
-- [ ] 1. Foundation: environment and test infrastructure setup
-- [ ] 1.1 Sub-task description
-  - Detail item 1
-  - Detail item 2
-  - Observable completion condition
-  - _Requirements: X.X_
+- [ ] 1. {{LOCALIZED_SETUP_PHASE_TITLE}}
+- [ ] 1.1 {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEM_1}}
+  - {{LOCALIZED_DETAIL_ITEM_2}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ X.X
+  - _Boundary:_ SharedSetup
+  - _Depends:_ none
 
-- [ ] 2. Core feature A
-- [ ] 2.1 (P) Sub-task description
-  - Detail items...
-  - Observable completion condition
-  - _Requirements: Y.Y_
-  - _Boundary: AuthService_
+- [ ] 2. {{LOCALIZED_PRIMARY_FEATURE_PHASE_TITLE}}
+- [ ] 2.1 (P) {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEMS}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ Y.Y
+  - _Boundary:_ AuthService
+  - _Depends:_ none
 
-- [ ] 2.2 (P) Sub-task description
-  - Detail items...
-  - Observable completion condition
-  - _Requirements: Z.Z_
-  - _Boundary: UserRepository_
+- [ ] 2.2 (P) {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEMS}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ Z.Z
+  - _Boundary:_ UserRepository
+  - _Depends:_ none
 
-- [ ] 3. Integration and wiring
-- [ ] 3.1 Sub-task description
-  - Detail items...
-  - Observable completion condition
-  - _Depends: 2.1, 2.2_
-  - _Requirements: W.W_
+- [ ] 3. {{LOCALIZED_INTEGRATION_PHASE_TITLE}}
+- [ ] 3.1 {{LOCALIZED_SUB_TASK_DESCRIPTION}}
+  - {{LOCALIZED_DETAIL_ITEMS}}
+  - {{LOCALIZED_OBSERVABLE_COMPLETION_CONDITION}}
+  - _Requirements:_ W.W
+  - _Boundary:_ {{INTEGRATION_BOUNDARY}}
+  - _Depends:_ 2.1, 2.2
 ```
 
 ## Requirements Coverage
@@ -217,6 +256,6 @@ Before writing `tasks.md`, review the draft task plan and repair local issues un
 - If gaps found: Return to requirements or design phase
 - No requirement should be left without corresponding tasks
 
-Use `N.M`-style numeric requirement IDs where `N` is the top-level requirement number from requirements.md (for example, Requirement 1 → 1.1, 1.2; Requirement 2 → 2.1, 2.2), and `M` is a local index within that requirement group.
+Use `N.M`-style numeric requirement IDs where `N` is the top-level requirement number from requirements.md, regardless of which requirement heading term from `.kiro/settings/templates/specs/localized-spec-terminology.md` the artifact uses.
 
 Document any intentionally deferred requirements with rationale.

--- a/.claude/skills/kiro-spec-tasks/rules/tasks-parallel-analysis.md
+++ b/.claude/skills/kiro-spec-tasks/rules/tasks-parallel-analysis.md
@@ -36,6 +36,6 @@ Before marking a task with `(P)`, ensure you have:
 - Confirmed `_Boundary:_` annotations show non-overlapping component scopes.
 - Captured any shared state expectations in the detail bullets.
 - Confirmed that the implementation can be tested independently.
-- Added `_Depends: X.X_` if this `(P)` task still requires specific prior work from a different major-task group.
+- Added `_Depends:_ X.X` if this `(P)` task still requires specific prior work from a different major-task group.
 
 If any check fails, **do not** mark the task with `(P)` and explain the dependency in the task details.

--- a/.claude/skills/kiro-validate-impl/SKILL.md
+++ b/.claude/skills/kiro-validate-impl/SKILL.md
@@ -12,7 +12,7 @@ Individual tasks have already been reviewed by the per-task reviewer during impl
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
-- design fixes `Boundary Commitments`
+- design fixes the design boundary section named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - tasks constrain execution with `_Boundary:_`
 - feature validation checks for cross-task `Boundary Violations`
 
@@ -57,6 +57,7 @@ Otherwise, for each detected feature:
 - Read `.kiro/specs/<feature>/requirements.md` for requirements
 - Read `.kiro/specs/<feature>/design.md` for design structure
 - Read `.kiro/specs/<feature>/tasks.md` for task list and Implementation Notes
+- Read `.kiro/settings/templates/specs/localized-spec-terminology.md` and resolve language-specific section terms from `spec.json.language` before design boundary checks
 - Core steering context: `product.md`, `tech.md`, `structure.md`
 - Additional steering files only when directly relevant to the validated boundaries, runtime prerequisites, integrations, domain rules, security/performance constraints, or team conventions that affect the GO/NO-GO call
 
@@ -123,12 +124,12 @@ These checks apply at the feature level. Use command output as the primary signa
 - Verify the overall component graph matches design.md
 - Check that integration patterns (event flow, API boundaries, dependency injection) work as designed
 - Verify dependency direction follows design.md's architecture (no upward imports)
-- Verify File Structure Plan matches the actual file layout
+- Verify the file structure section named by `.kiro/settings/templates/specs/localized-spec-terminology.md` matches the actual file layout
 - Identify any architectural drift from the original design
 - Use the original section numbering from `design.md`
 
 **G.5 Boundary Audit**
-- Compare completed work against the design's `Boundary Commitments`, `Out of Boundary`, `Allowed Dependencies`, and `Revalidation Triggers`
+- Compare completed work against the boundary terms named by `.kiro/settings/templates/specs/localized-spec-terminology.md`
 - Identify cross-task spillover where one area quietly absorbed another boundary's responsibility
 - Identify downstream-specific workarounds embedded upstream "to make integration easier"
 - Identify new hidden dependencies or shared ownership that were not declared in the design
@@ -169,7 +170,7 @@ Provide summary in the language specified in spec.json:
 - DESIGN:
   - Architecture drift: <findings>
   - Dependency direction: <violations if any>
-  - File Structure Plan vs actual: <match/mismatch>
+  - File structure plan vs actual: <match/mismatch>
 - OWNERSHIP: LOCAL | UPSTREAM | UNCLEAR
 - UPSTREAM_SPEC: <feature-name | N/A>
 - BLOCKED_TASKS: <list and impact assessment>

--- a/.kiro/settings/templates/specs/design.en.md
+++ b/.kiro/settings/templates/specs/design.en.md
@@ -1,0 +1,331 @@
+# Design Document Template
+
+---
+**Purpose**: Provide sufficient detail to ensure implementation consistency across different implementers, preventing interpretation drift.
+
+**Approach**:
+- Include essential sections that directly inform implementation decisions
+- Omit optional sections unless critical to preventing implementation errors
+- Match detail level to feature complexity
+- Use diagrams and tables over lengthy prose
+
+**Warning**: Approaching 1000 lines indicates excessive feature complexity that may require design simplification or splitting into multiple specs.
+---
+
+> Sections may be reordered (e.g., surfacing Requirements Traceability earlier or moving Data Models nearer Architecture) when it improves clarity. Within each section, keep the flow **Summary → Scope → Decisions → Impacts/Risks** so reviewers can scan consistently.
+
+## Overview
+2-3 paragraphs max
+**Purpose**: This feature delivers [specific value] to [target users].
+**Users**: [Target user groups] will utilize this for [specific workflows].
+**Impact** (if applicable): Changes the current [system state] by [specific modifications].
+
+
+### Goals
+- Primary objective 1
+- Primary objective 2
+- Success criteria
+
+### Non-Goals
+- Explicitly excluded functionality
+- Future considerations outside current scope
+- Integration points deferred
+
+## Boundary Commitments
+
+State the responsibility boundary of this spec in concrete terms. Treat this as the anchor for architecture, tasks, and later validation.
+
+### This Spec Owns
+- Capabilities and behaviors this spec is responsible for
+- Data it owns or is authoritative for
+- Interfaces or contracts it defines or stabilizes
+
+### Out of Boundary
+- Related concerns this spec explicitly does NOT own
+- Work deferred to another spec, existing subsystem, or later phase
+- Changes this spec must not absorb as "just one more thing"
+
+### Allowed Dependencies
+- Upstream systems/specs/components this design may depend on
+- Shared infrastructure this design may use
+- Dependency constraints that must not be violated
+
+### Revalidation Triggers
+List the kinds of changes that should force dependent specs or consumers to re-check integration.
+
+- Contract shape changes
+- Data ownership changes
+- Dependency direction changes
+- Startup/runtime prerequisite changes
+
+## Architecture
+
+> Reference detailed discovery notes in `research.md` only for background; keep design.md self-contained for reviewers by capturing all decisions and contracts here.
+> Capture key decisions in text and let diagrams carry structural detail—avoid repeating the same information in prose.
+> Supporting sections below should remain as light as possible unless they materially clarify the responsibility boundary, dependency rules, or integration seams.
+
+### Existing Architecture Analysis (if applicable)
+When modifying existing systems:
+- Current architecture patterns and constraints
+- Existing domain boundaries to be respected
+- Integration points that must be maintained
+- Technical debt addressed or worked around
+
+### Architecture Pattern and Boundary Map
+**RECOMMENDED**: Include Mermaid diagram showing the chosen architecture pattern and system boundaries (required for complex features, optional for simple additions)
+
+**Architecture Integration**:
+- Selected pattern: [name and brief rationale]
+- Domain/feature boundaries: [how responsibilities are separated to avoid conflicts]
+- Existing patterns preserved: [list key patterns]
+- New components rationale: [why each is needed]
+- Steering compliance: [principles maintained]
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend / CLI | | | |
+| Backend / Services | | | |
+| Data / Storage | | | |
+| Messaging / Events | | | |
+| Infrastructure / Runtime | | | |
+
+> Keep rationale concise here and, when more depth is required (trade-offs, benchmarks), add a short summary plus pointer to the Supporting References section and `research.md` for raw investigation notes.
+
+## File Structure Plan
+
+Map the directory structure and file responsibilities for this feature. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs. Use the appropriate level of detail:
+
+- **Small features**: List individual files with responsibilities
+- **Large features**: Describe directory-level structure + per-domain/module pattern, list only non-obvious files individually
+
+### Directory Structure
+```
+src/
+├── domain-a/              # Domain A responsibility
+│   ├── controller.ts      # Endpoint handlers
+│   ├── service.ts         # Business logic
+│   └── types.ts           # Domain types
+├── domain-b/              # Domain B (same pattern as domain-a)
+└── shared/
+    └── cross-cutting.ts   # Non-obvious: why this exists
+```
+
+> For repeated structures, describe the pattern once (e.g., "domain-b follows same pattern as domain-a"). List individual files only when their responsibility isn't obvious from the path.
+
+### Modified Files
+- `path/to/existing.ts` — What changes and why
+
+> Each file should have one clear responsibility. Group files that change together. For repeated structures, describe the pattern once rather than listing every file.
+> Avoid duplicating what Components and Interfaces already describes — focus on the physical file layout that Components maps to.
+
+## System Flows
+
+Provide only the diagrams needed to explain non-trivial flows. Use pure Mermaid syntax. Common patterns:
+- Sequence (multi-party interactions)
+- Process / state (branching logic or lifecycle)
+- Data / event flow (pipelines, async messaging)
+
+Skip this section entirely for simple CRUD changes.
+> Describe flow-level decisions (e.g., gating conditions, retries) briefly after the diagram instead of restating each step.
+
+## Requirements Traceability
+
+Use this section for complex or compliance-sensitive features where requirements span multiple domains. Straightforward 1:1 mappings can rely on the Components summary table.
+
+Map each requirement ID (e.g., `2.1`) to the design elements that realize it.
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | | | | |
+| 1.2 | | | | |
+
+> Omit this section only when a single component satisfies a single requirement without cross-cutting concerns.
+
+## Components and Interfaces
+
+Provide a quick reference before diving into per-component details.
+
+- Summaries can be a table or compact list. Example table:
+  | Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+  |-----------|--------------|--------|--------------|--------------------------|-----------|
+  | ExampleComponent | UI | Displays XYZ | 1, 2 | GameProvider (P0), MapPanel (P1) | Service, State |
+- Only components introducing new boundaries (e.g., logic hooks, external integrations, persistence) require full detail blocks. Simple presentation components can rely on the summary row plus a short Implementation Note.
+
+Group detailed blocks by domain or architectural layer. For each detailed component, list requirement IDs as `2.1, 2.3` (omit “Requirement”). When multiple UI components share the same contract, reference a base interface/props definition instead of duplicating code blocks.
+
+### [Domain / Layer]
+
+#### [Component Name]
+
+| Field | Detail |
+|-------|--------|
+| Intent | 1-line description of the responsibility |
+| Requirements | 2.1, 2.3 |
+| Owner / Reviewers | (optional) |
+
+**Responsibilities & Constraints**
+- Primary responsibility
+- Domain boundary and transaction scope
+- Data ownership / invariants
+
+**Dependencies**
+- Inbound: Component/service name — purpose (Criticality)
+- Outbound: Component/service name — purpose (Criticality)
+- External: Service/library — purpose (Criticality)
+
+Summarize external dependency findings here; deeper investigation (API signatures, rate limits, migration notes) lives in `research.md`.
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [ ]  ← check only the ones that apply.
+
+##### Service Interface
+```typescript
+interface [ComponentName]Service {
+  methodName(input: InputType): Result<OutputType, ErrorType>;
+}
+```
+- Preconditions:
+- Postconditions:
+- Invariants:
+
+##### API Contract
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| POST | /api/resource | CreateRequest | Resource | 400, 409, 500 |
+
+##### Event Contract
+- Published events:
+- Subscribed events:
+- Ordering / delivery guarantees:
+
+##### Batch / Job Contract
+- Trigger:
+- Input / validation:
+- Output / destination:
+- Idempotency & recovery:
+
+##### State Management
+- State model:
+- Persistence & consistency:
+- Concurrency strategy:
+
+**Implementation Notes**
+- Integration:
+- Validation:
+- Risks:
+
+## Data Models
+
+Focus on the portions of the data landscape that change with this feature.
+
+### Domain Model
+- Aggregates and transactional boundaries
+- Entities, value objects, domain events
+- Business rules & invariants
+- Optional Mermaid diagram for complex relationships
+
+### Logical Data Model
+
+**Structure Definition**:
+- Entity relationships and cardinality
+- Attributes and their types
+- Natural keys and identifiers
+- Referential integrity rules
+
+**Consistency & Integrity**:
+- Transaction boundaries
+- Cascading rules
+- Temporal aspects (versioning, audit)
+
+### Physical Data Model
+**When to include**: When implementation requires specific storage design decisions
+
+**For Relational Databases**:
+- Table definitions with data types
+- Primary/foreign keys and constraints
+- Indexes and performance optimizations
+- Partitioning strategy for scale
+
+**For Document Stores**:
+- Collection structures
+- Embedding vs referencing decisions
+- Sharding key design
+- Index definitions
+
+**For Event Stores**:
+- Event schema definitions
+- Stream aggregation strategies
+- Snapshot policies
+- Projection definitions
+
+**For Key-Value/Wide-Column Stores**:
+- Key design patterns
+- Column families or value structures
+- TTL and compaction strategies
+
+### Data Contracts & Integration
+
+**API Data Transfer**
+- Request/response schemas
+- Validation rules
+- Serialization format (JSON, Protobuf, etc.)
+
+**Event Schemas**
+- Published event structures
+- Schema versioning strategy
+- Backward/forward compatibility rules
+
+**Cross-Service Data Management**
+- Distributed transaction patterns (Saga, 2PC)
+- Data synchronization strategies
+- Eventual consistency handling
+
+Skip subsections that are not relevant to this feature.
+
+## Error Handling
+
+### Error Strategy
+Concrete error handling patterns and recovery mechanisms for each error type.
+
+### Error Categories and Responses
+**User Errors** (4xx): Invalid input → field-level validation; Unauthorized → auth guidance; Not found → navigation help
+**System Errors** (5xx): Infrastructure failures → graceful degradation; Timeouts → circuit breakers; Exhaustion → rate limiting
+**Business Logic Errors** (422): Rule violations → condition explanations; State conflicts → transition guidance
+
+**Process Flow Visualization** (when complex business logic exists):
+Include Mermaid flowchart only for complex error scenarios with business workflows.
+
+### Monitoring
+Error tracking, logging, and health monitoring implementation.
+
+## Testing Strategy
+
+### Default sections (adapt names/sections to fit the domain)
+- Unit Tests: 3–5 items from core functions/modules (e.g., auth methods, subscription logic)
+- Integration Tests: 3–5 cross-component flows (e.g., webhook handling, notifications)
+- E2E/UI Tests (if applicable): 3–5 critical user paths (e.g., forms, dashboards)
+- Performance/Load (if applicable): 3–4 items (e.g., concurrency, high-volume ops)
+
+## Optional Sections (include when relevant)
+
+### Security Considerations
+_Use this section for features handling auth, sensitive data, external integrations, or user permissions. Capture only decisions unique to this feature; defer baseline controls to steering docs._
+- Threat modeling, security controls, compliance requirements
+- Authentication and authorization patterns
+- Data protection and privacy considerations
+
+### Performance & Scalability
+_Use this section when performance targets, high load, or scaling concerns exist. Record only feature-specific targets or trade-offs and rely on steering documents for general practices._
+- Target metrics and measurement strategies
+- Scaling approaches (horizontal/vertical)
+- Caching strategies and optimization techniques
+
+### Migration Strategy
+Include a Mermaid flowchart showing migration phases when schema/data movement is required.
+- Phase breakdown, rollback triggers, validation checkpoints
+
+## Supporting References (Optional)
+- Create this section only when keeping the information in the main body would hurt readability (e.g., very long TypeScript definitions, vendor option matrices, exhaustive schema tables). Keep decision-making context in the main sections so the design stays self-contained.
+- Link to the supporting references from the main text instead of inlining large snippets.
+- Background research notes and comparisons continue to live in `research.md`, but their conclusions must be summarized in the main design.

--- a/.kiro/settings/templates/specs/design.md
+++ b/.kiro/settings/templates/specs/design.md
@@ -1,331 +1,331 @@
-# Design Document Template
+# 設計ドキュメントテンプレート
 
 ---
-**Purpose**: Provide sufficient detail to ensure implementation consistency across different implementers, preventing interpretation drift.
+**目的**: 実装者が異なっても実装の一貫性を保てるだけの詳細を提供し、解釈のズレを防ぐ。
 
-**Approach**:
-- Include essential sections that directly inform implementation decisions
-- Omit optional sections unless critical to preventing implementation errors
-- Match detail level to feature complexity
-- Use diagrams and tables over lengthy prose
+**アプローチ**:
+- 実装判断に直接つながる必須セクションを含める
+- 実装エラーの防止に不可欠でない限り、任意セクションは省く
+- 詳細度を機能の複雑さに合わせる
+- 長い散文よりも図表を用いる
 
-**Warning**: Approaching 1000 lines indicates excessive feature complexity that may require design simplification or splitting into multiple specs.
+**警告**: 1000行に近づく場合、機能が過度に複雑であることを示す。設計の単純化、または複数スペックへの分割を検討する。
 ---
 
-> Sections may be reordered (e.g., surfacing Requirements Traceability earlier or moving Data Models nearer Architecture) when it improves clarity. Within each section, keep the flow **Summary → Scope → Decisions → Impacts/Risks** so reviewers can scan consistently.
+> 明確さが増すなら、セクションを並べ替えてもよい（例: 要件トレーサビリティを前に出す、データモデルをアーキテクチャの近くに移す）。各セクション内では **要約 → スコープ → 判断 → 影響／リスク** の流れを保ち、レビュアーが一貫して読めるようにする。
 
-## Overview 
-2-3 paragraphs max
-**Purpose**: This feature delivers [specific value] to [target users].
-**Users**: [Target user groups] will utilize this for [specific workflows].
-**Impact** (if applicable): Changes the current [system state] by [specific modifications].
+## 概要
+最大2〜3段落。
+**Purpose（目的）**: この機能は [対象ユーザー] に [具体的な価値] を提供する。
+**Users（ユーザー）**: [対象ユーザー層] が [具体的なワークフロー] のために利用する。
+**Impact（影響）**（該当する場合）: 現在の [システム状態] を [具体的な変更] によって変える。
 
 
-### Goals
-- Primary objective 1
-- Primary objective 2  
-- Success criteria
+### 目標
+- 主要目的 1
+- 主要目的 2
+- 成功基準
 
-### Non-Goals
-- Explicitly excluded functionality
-- Future considerations outside current scope
-- Integration points deferred
+### 非目標
+- 明示的に除外する機能
+- 現スコープ外の将来検討事項
+- 先送りする統合ポイント
 
-## Boundary Commitments
+## 境界コミットメント
 
-State the responsibility boundary of this spec in concrete terms. Treat this as the anchor for architecture, tasks, and later validation.
+このスペックの責任境界を具体的に述べる。これをアーキテクチャ・タスク・後続の検証のアンカーとして扱う。
 
-### This Spec Owns
-- Capabilities and behaviors this spec is responsible for
-- Data it owns or is authoritative for
-- Interfaces or contracts it defines or stabilizes
+### このスペックが所有するもの
+- このスペックが責任を負う能力・振る舞い
+- このスペックが所有、または信頼できる正本（authoritative）となるデータ
+- このスペックが定義、または安定化させるインターフェース・契約
 
-### Out of Boundary
-- Related concerns this spec explicitly does NOT own
-- Work deferred to another spec, existing subsystem, or later phase
-- Changes this spec must not absorb as "just one more thing"
+### 境界外
+- このスペックが明示的に所有「しない」関連事項
+- 別スペック・既存サブシステム・後フェーズに委ねる作業
+- 「ついでに一つだけ」と取り込んではならない変更
 
-### Allowed Dependencies
-- Upstream systems/specs/components this design may depend on
-- Shared infrastructure this design may use
-- Dependency constraints that must not be violated
+### 許可する依存
+- この設計が依存してよい上流のシステム／スペック／コンポーネント
+- この設計が利用してよい共有インフラ
+- 違反してはならない依存制約
 
-### Revalidation Triggers
-List the kinds of changes that should force dependent specs or consumers to re-check integration.
+### 再検証トリガー
+依存スペックや利用側に統合の再確認を強制すべき変更の種類を列挙する。
 
-- Contract shape changes
-- Data ownership changes
-- Dependency direction changes
-- Startup/runtime prerequisite changes
+- 契約（contract）の形状変更
+- データ所有権の変更
+- 依存方向の変更
+- 起動時／実行時の前提条件の変更
 
-## Architecture
+## アーキテクチャ
 
-> Reference detailed discovery notes in `research.md` only for background; keep design.md self-contained for reviewers by capturing all decisions and contracts here.
-> Capture key decisions in text and let diagrams carry structural detail—avoid repeating the same information in prose.
-> Supporting sections below should remain as light as possible unless they materially clarify the responsibility boundary, dependency rules, or integration seams.
+> 詳細なディスカバリーノートは背景としてのみ `research.md` を参照する。すべての決定と契約をここに記録し、レビュアーにとって design.md が自己完結するように保つ。
+> 主要な決定はテキストで記し、構造的な詳細は図に担わせる。同じ情報を散文で繰り返さない。
+> 以下の補足セクションは、責任境界・依存ルール・統合の接合部を実質的に明確化する場合を除き、できる限り軽量に保つ。
 
-### Existing Architecture Analysis (if applicable)
-When modifying existing systems:
-- Current architecture patterns and constraints
-- Existing domain boundaries to be respected
-- Integration points that must be maintained
-- Technical debt addressed or worked around
+### 既存アーキテクチャ分析（該当する場合）
+既存システムを変更する場合:
+- 現在のアーキテクチャパターンと制約
+- 尊重すべき既存のドメイン境界
+- 維持しなければならない統合ポイント
+- 解消または回避する技術的負債
 
-### Architecture Pattern & Boundary Map
-**RECOMMENDED**: Include Mermaid diagram showing the chosen architecture pattern and system boundaries (required for complex features, optional for simple additions)
+### アーキテクチャパターンと境界マップ
+**推奨**: 採用するアーキテクチャパターンとシステム境界を示す Mermaid 図を含める（複雑な機能では必須、単純な追加では任意）
 
-**Architecture Integration**:
-- Selected pattern: [name and brief rationale]
-- Domain/feature boundaries: [how responsibilities are separated to avoid conflicts]
-- Existing patterns preserved: [list key patterns]
-- New components rationale: [why each is needed]
-- Steering compliance: [principles maintained]
+**Architecture Integration（アーキテクチャ統合）**:
+- 採用パターン: [名称と簡潔な根拠]
+- ドメイン／機能境界: [競合を避けるための責任分割の方法]
+- 維持する既存パターン: [主要なパターンを列挙]
+- 新規コンポーネントの根拠: [それぞれがなぜ必要か]
+- ステアリング準拠: [維持する原則]
 
-### Technology Stack
+### 技術スタック
 
-| Layer | Choice / Version | Role in Feature | Notes |
+| レイヤー | 選択／バージョン | 機能内での役割 | メモ |
 |-------|------------------|-----------------|-------|
-| Frontend / CLI | | | |
-| Backend / Services | | | |
-| Data / Storage | | | |
-| Messaging / Events | | | |
-| Infrastructure / Runtime | | | |
+| フロントエンド／CLI | | | |
+| バックエンド／サービス | | | |
+| データ／ストレージ | | | |
+| メッセージング／イベント | | | |
+| インフラ／ランタイム | | | |
 
-> Keep rationale concise here and, when more depth is required (trade-offs, benchmarks), add a short summary plus pointer to the Supporting References section and `research.md` for raw investigation notes.
+> 根拠はここでは簡潔にまとめる。より深い検討（トレードオフ、ベンチマーク）が必要な場合は、短い要約に加えて Supporting References セクションと、生の調査ノートである `research.md` へのポインタを添える。
 
-## File Structure Plan
+## ファイル構造計画
 
-Map the directory structure and file responsibilities for this feature. This section directly drives task `_Boundary:_` annotations and implementation Task Briefs. Use the appropriate level of detail:
+この機能のディレクトリ構造とファイル責務をマッピングする。このセクションはタスクの `_Boundary:_` 注釈と、実装時の Task Brief を直接駆動する。適切な詳細度を用いる:
 
-- **Small features**: List individual files with responsibilities
-- **Large features**: Describe directory-level structure + per-domain/module pattern, list only non-obvious files individually
+- **小さな機能**: 個々のファイルとその責務を列挙する
+- **大きな機能**: ディレクトリレベルの構造 + ドメイン／モジュール単位のパターンを記述し、自明でないファイルのみ個別に列挙する
 
-### Directory Structure
+### ディレクトリ構造
 ```
 src/
-├── domain-a/              # Domain A responsibility
-│   ├── controller.ts      # Endpoint handlers
-│   ├── service.ts         # Business logic
-│   └── types.ts           # Domain types
-├── domain-b/              # Domain B (same pattern as domain-a)
+├── domain-a/              # ドメインAの責務
+│   ├── controller.ts      # エンドポイントのハンドラ
+│   ├── service.ts         # ビジネスロジック
+│   └── types.ts           # ドメイン型
+├── domain-b/              # ドメインB（domain-a と同じパターン）
 └── shared/
-    └── cross-cutting.ts   # Non-obvious: why this exists
+    └── cross-cutting.ts   # 自明でない: なぜ存在するか
 ```
 
-> For repeated structures, describe the pattern once (e.g., "domain-b follows same pattern as domain-a"). List individual files only when their responsibility isn't obvious from the path.
+> 繰り返し現れる構造は、一度だけパターンを記述する（例:「domain-b は domain-a と同じパターン」）。パスから責務が自明でないファイルのみ個別に列挙する。
 
-### Modified Files
-- `path/to/existing.ts` — What changes and why
+### 変更対象ファイル
+- `path/to/existing.ts` — 何をなぜ変更するか
 
-> Each file should have one clear responsibility. Group files that change together. For repeated structures, describe the pattern once rather than listing every file.
-> Avoid duplicating what Components and Interfaces already describes — focus on the physical file layout that Components maps to.
+> 各ファイルは1つの明確な責務を持つこと。同時に変わるファイルはまとめる。繰り返し現れる構造は、すべてのファイルを列挙せず一度だけパターンを記述する。
+> Components and Interfaces が既に説明している内容を重複させない。Components が対応する物理的なファイル配置に焦点を当てる。
 
-## System Flows
+## システムフロー
 
-Provide only the diagrams needed to explain non-trivial flows. Use pure Mermaid syntax. Common patterns:
-- Sequence (multi-party interactions)
-- Process / state (branching logic or lifecycle)
-- Data / event flow (pipelines, async messaging)
+自明でないフローの説明に必要な図のみを提供する。純粋な Mermaid 構文を用いる。よくあるパターン:
+- シーケンス（複数主体の相互作用）
+- プロセス／状態（分岐ロジックやライフサイクル）
+- データ／イベントフロー（パイプライン、非同期メッセージング）
 
-Skip this section entirely for simple CRUD changes.
-> Describe flow-level decisions (e.g., gating conditions, retries) briefly after the diagram instead of restating each step.
+単純な CRUD 変更ではこのセクションを丸ごと省略する。
+> ゲート条件やリトライなどのフローレベルの判断は、各ステップを再掲するのではなく、図の後に簡潔に記述する。
 
-## Requirements Traceability
+## 要件トレーサビリティ
 
-Use this section for complex or compliance-sensitive features where requirements span multiple domains. Straightforward 1:1 mappings can rely on the Components summary table.
+要件が複数ドメインにまたがる、複雑またはコンプライアンス上重要な機能で用いる。単純な1対1のマッピングは Components の要約テーブルで足りる。
 
-Map each requirement ID (e.g., `2.1`) to the design elements that realize it.
+各要件ID（例: `2.1`）を、それを実現する設計要素に対応づける。
 
-| Requirement | Summary | Components | Interfaces | Flows |
+| 要件 | 要約 | コンポーネント | インターフェース | フロー |
 |-------------|---------|------------|------------|-------|
 | 1.1 | | | | |
 | 1.2 | | | | |
 
-> Omit this section only when a single component satisfies a single requirement without cross-cutting concerns.
+> 単一のコンポーネントが、横断的関心事なしに単一の要件を満たす場合のみ、このセクションを省略する。
 
-## Components and Interfaces
+## コンポーネントとインターフェース
 
-Provide a quick reference before diving into per-component details.
+コンポーネントごとの詳細に入る前に、クイックリファレンスを提供する。
 
-- Summaries can be a table or compact list. Example table:
-  | Component | Domain/Layer | Intent | Req Coverage | Key Dependencies (P0/P1) | Contracts |
+- 要約はテーブルまたはコンパクトな箇条書きでよい。テーブル例:
+  | コンポーネント | ドメイン／レイヤー | 意図 | 要件カバー範囲 | 主要依存 (P0/P1) | 契約 |
   |-----------|--------------|--------|--------------|--------------------------|-----------|
-  | ExampleComponent | UI | Displays XYZ | 1, 2 | GameProvider (P0), MapPanel (P1) | Service, State |
-- Only components introducing new boundaries (e.g., logic hooks, external integrations, persistence) require full detail blocks. Simple presentation components can rely on the summary row plus a short Implementation Note.
+  | ExampleComponent | UI | XYZ を表示 | 1, 2 | GameProvider (P0), MapPanel (P1) | Service, State |
+- 新たな境界を導入するコンポーネント（ロジックフック、外部統合、永続化など）のみ、詳細ブロックが必要。単純な表示コンポーネントは、要約行 + 短い実装メモで足りる。
 
-Group detailed blocks by domain or architectural layer. For each detailed component, list requirement IDs as `2.1, 2.3` (omit “Requirement”). When multiple UI components share the same contract, reference a base interface/props definition instead of duplicating code blocks.
+詳細ブロックはドメインまたはアーキテクチャ層ごとにまとめる。各詳細コンポーネントでは、要件IDを `2.1, 2.3` のように記す（"Requirement" は省く）。複数のUIコンポーネントが同じ契約を共有する場合は、コードブロックを重複させず、ベースとなるインターフェース／props 定義を参照する。
 
-### [Domain / Layer]
+### [ドメイン／レイヤー]
 
-#### [Component Name]
+#### [コンポーネント名]
 
-| Field | Detail |
+| 項目 | 詳細 |
 |-------|--------|
-| Intent | 1-line description of the responsibility |
-| Requirements | 2.1, 2.3 |
-| Owner / Reviewers | (optional) |
+| 意図 | 責務を1行で説明 |
+| 要件 | 2.1, 2.3 |
+| 所有者／レビュアー | （任意） |
 
-**Responsibilities & Constraints**
-- Primary responsibility
-- Domain boundary and transaction scope
-- Data ownership / invariants
+**責務と制約**
+- 主要な責務
+- ドメイン境界とトランザクション範囲
+- データ所有権／不変条件
 
-**Dependencies**
-- Inbound: Component/service name — purpose (Criticality)
-- Outbound: Component/service name — purpose (Criticality)
-- External: Service/library — purpose (Criticality)
+**依存**
+- 流入: コンポーネント／サービス名 — 目的（重要度）
+- 流出: コンポーネント／サービス名 — 目的（重要度）
+- 外部: サービス／ライブラリ — 目的（重要度）
 
-Summarize external dependency findings here; deeper investigation (API signatures, rate limits, migration notes) lives in `research.md`.
+外部依存の調査結果はここに要約する。より深い調査（APIシグネチャ、レート制限、移行メモ）は `research.md` に置く。
 
-**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [ ]  ← check only the ones that apply.
+**契約種別**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [ ]  ← 該当するものだけチェックする。
 
-##### Service Interface
+##### サービスインターフェース
 ```typescript
 interface [ComponentName]Service {
   methodName(input: InputType): Result<OutputType, ErrorType>;
 }
 ```
-- Preconditions:
-- Postconditions:
-- Invariants:
+- Preconditions（事前条件）:
+- Postconditions（事後条件）:
+- Invariants（不変条件）:
 
-##### API Contract
-| Method | Endpoint | Request | Response | Errors |
+##### API契約
+| メソッド | エンドポイント | リクエスト | レスポンス | エラー |
 |--------|----------|---------|----------|--------|
 | POST | /api/resource | CreateRequest | Resource | 400, 409, 500 |
 
-##### Event Contract
-- Published events:  
-- Subscribed events:  
-- Ordering / delivery guarantees:
+##### イベント契約
+- Published events（発行イベント）:
+- Subscribed events（購読イベント）:
+- Ordering / delivery guarantees（順序／配信保証）:
 
-##### Batch / Job Contract
-- Trigger:  
-- Input / validation:  
-- Output / destination:  
-- Idempotency & recovery:
+##### バッチ／ジョブ契約
+- Trigger（トリガー）:
+- Input / validation（入力／検証）:
+- Output / destination（出力／宛先）:
+- Idempotency & recovery（冪等性と回復）:
 
-##### State Management
-- State model:  
-- Persistence & consistency:  
-- Concurrency strategy:
+##### 状態管理
+- State model（状態モデル）:
+- Persistence & consistency（永続化と整合性）:
+- Concurrency strategy（並行制御戦略）:
 
-**Implementation Notes**
-- Integration: 
-- Validation: 
-- Risks:
+**Implementation Notes（実装メモ）**
+- Integration（統合）:
+- Validation（検証）:
+- Risks（リスク）:
 
-## Data Models
+## データモデル
 
-Focus on the portions of the data landscape that change with this feature.
+この機能で変化するデータ領域に焦点を当てる。
 
-### Domain Model
-- Aggregates and transactional boundaries
-- Entities, value objects, domain events
-- Business rules & invariants
-- Optional Mermaid diagram for complex relationships
+### ドメインモデル
+- 集約（アグリゲート）とトランザクション境界
+- エンティティ、値オブジェクト、ドメインイベント
+- ビジネスルールと不変条件
+- 複雑な関係には任意で Mermaid 図
 
-### Logical Data Model
+### 論理データモデル
 
-**Structure Definition**:
-- Entity relationships and cardinality
-- Attributes and their types
-- Natural keys and identifiers
-- Referential integrity rules
+**Structure Definition（構造定義）**:
+- エンティティ間の関係とカーディナリティ
+- 属性とその型
+- 自然キーと識別子
+- 参照整合性ルール
 
-**Consistency & Integrity**:
-- Transaction boundaries
-- Cascading rules
-- Temporal aspects (versioning, audit)
+**Consistency & Integrity（整合性）**:
+- トランザクション境界
+- カスケードルール
+- 時間的側面（バージョニング、監査）
 
-### Physical Data Model
-**When to include**: When implementation requires specific storage design decisions
+### 物理データモデル
+**含めるとき**: 実装に特定のストレージ設計判断が必要な場合
 
-**For Relational Databases**:
-- Table definitions with data types
-- Primary/foreign keys and constraints
-- Indexes and performance optimizations
-- Partitioning strategy for scale
+**リレーショナルDBの場合**:
+- データ型付きのテーブル定義
+- 主キー／外部キーと制約
+- インデックスと性能最適化
+- スケール向けのパーティショニング戦略
 
-**For Document Stores**:
-- Collection structures
-- Embedding vs referencing decisions
-- Sharding key design
-- Index definitions
+**ドキュメントストアの場合**:
+- コレクション構造
+- 埋め込み（embedding）か参照（referencing）かの判断
+- シャーディングキー設計
+- インデックス定義
 
-**For Event Stores**:
-- Event schema definitions
-- Stream aggregation strategies
-- Snapshot policies
-- Projection definitions
+**イベントストアの場合**:
+- イベントスキーマ定義
+- ストリーム集約戦略
+- スナップショットポリシー
+- プロジェクション定義
 
-**For Key-Value/Wide-Column Stores**:
-- Key design patterns
-- Column families or value structures
-- TTL and compaction strategies
+**キーバリュー／ワイドカラムストアの場合**:
+- キー設計パターン
+- カラムファミリーまたは値の構造
+- TTL とコンパクション戦略
 
-### Data Contracts & Integration
+### データ契約と統合
 
-**API Data Transfer**
-- Request/response schemas
-- Validation rules
-- Serialization format (JSON, Protobuf, etc.)
+**API Data Transfer（APIデータ転送）**
+- リクエスト／レスポンスのスキーマ
+- バリデーションルール
+- シリアライズ形式（JSON、Protobuf など）
 
-**Event Schemas**
-- Published event structures
-- Schema versioning strategy
-- Backward/forward compatibility rules
+**Event Schemas（イベントスキーマ）**
+- 発行イベントの構造
+- スキーマのバージョニング戦略
+- 後方／前方互換性のルール
 
-**Cross-Service Data Management**
-- Distributed transaction patterns (Saga, 2PC)
-- Data synchronization strategies
-- Eventual consistency handling
+**Cross-Service Data Management（サービス間データ管理）**
+- 分散トランザクションパターン（Saga、2PC）
+- データ同期戦略
+- 結果整合性の扱い
 
-Skip subsections that are not relevant to this feature.
+この機能に関係しないサブセクションは省略する。
 
-## Error Handling
+## エラーハンドリング
 
-### Error Strategy
-Concrete error handling patterns and recovery mechanisms for each error type.
+### エラー戦略
+各エラー種別に対する、具体的なエラーハンドリングのパターンと回復メカニズム。
 
-### Error Categories and Responses
-**User Errors** (4xx): Invalid input → field-level validation; Unauthorized → auth guidance; Not found → navigation help
-**System Errors** (5xx): Infrastructure failures → graceful degradation; Timeouts → circuit breakers; Exhaustion → rate limiting  
-**Business Logic Errors** (422): Rule violations → condition explanations; State conflicts → transition guidance
+### エラー分類と応答
+**User Errors（ユーザーエラー）**（4xx）: 不正入力 → フィールド単位のバリデーション、未認可 → 認証の案内、未検出 → ナビゲーション補助
+**System Errors（システムエラー）**（5xx）: インフラ障害 → グレースフルデグラデーション、タイムアウト → サーキットブレーカー、枯渇 → レートリミット
+**Business Logic Errors（ビジネスロジックエラー）**（422）: ルール違反 → 条件の説明、状態の競合 → 遷移の案内
 
-**Process Flow Visualization** (when complex business logic exists):
-Include Mermaid flowchart only for complex error scenarios with business workflows.
+**Process Flow Visualization（プロセスフローの可視化）**（複雑なビジネスロジックがある場合）:
+ビジネスワークフローを伴う複雑なエラーシナリオに限り、Mermaid フローチャートを含める。
 
-### Monitoring
-Error tracking, logging, and health monitoring implementation.
+### 監視
+エラー追跡、ログ記録、ヘルス監視の実装。
 
-## Testing Strategy
+## テスト戦略
 
-### Default sections (adapt names/sections to fit the domain)
-- Unit Tests: 3–5 items from core functions/modules (e.g., auth methods, subscription logic)
-- Integration Tests: 3–5 cross-component flows (e.g., webhook handling, notifications)
-- E2E/UI Tests (if applicable): 3–5 critical user paths (e.g., forms, dashboards)
-- Performance/Load (if applicable): 3–4 items (e.g., concurrency, high-volume ops)
+### 既定セクション（ドメインに合わせて名称／セクションを調整する）
+- Unit Tests: コア関数／モジュールから3〜5項目（例: 認証メソッド、サブスクリプションロジック）
+- Integration Tests: コンポーネント横断のフロー3〜5項目（例: Webhook 処理、通知）
+- E2E/UI Tests（該当する場合）: クリティカルなユーザー経路3〜5項目（例: フォーム、ダッシュボード）
+- Performance/Load（該当する場合）: 3〜4項目（例: 並行性、大量処理）
 
-## Optional Sections (include when relevant)
+## 任意セクション（関連する場合のみ含める）
 
-### Security Considerations
-_Use this section for features handling auth, sensitive data, external integrations, or user permissions. Capture only decisions unique to this feature; defer baseline controls to steering docs._
-- Threat modeling, security controls, compliance requirements
-- Authentication and authorization patterns
-- Data protection and privacy considerations
+### セキュリティ考慮事項
+_認証、機微データ、外部統合、ユーザー権限を扱う機能で用いる。この機能に固有の決定のみを記録し、基本的な統制はステアリングドキュメントに委ねる。_
+- 脅威モデリング、セキュリティ統制、コンプライアンス要件
+- 認証・認可のパターン
+- データ保護とプライバシーの考慮
 
-### Performance & Scalability
-_Use this section when performance targets, high load, or scaling concerns exist. Record only feature-specific targets or trade-offs and rely on steering documents for general practices._
-- Target metrics and measurement strategies
-- Scaling approaches (horizontal/vertical)
-- Caching strategies and optimization techniques
+### 性能とスケーラビリティ
+_性能目標、高負荷、スケーリング上の懸念がある場合に用いる。機能固有の目標やトレードオフのみを記録し、一般的なプラクティスはステアリングドキュメントに依拠する。_
+- 目標メトリクスと測定戦略
+- スケーリング手法（水平／垂直）
+- キャッシュ戦略と最適化手法
 
-### Migration Strategy
-Include a Mermaid flowchart showing migration phases when schema/data movement is required.
-- Phase breakdown, rollback triggers, validation checkpoints
+### 移行戦略
+スキーマ／データ移動が必要な場合は、移行フェーズを示す Mermaid フローチャートを含める。
+- フェーズ分割、ロールバックのトリガー、検証チェックポイント
 
-## Supporting References (Optional)
-- Create this section only when keeping the information in the main body would hurt readability (e.g., very long TypeScript definitions, vendor option matrices, exhaustive schema tables). Keep decision-making context in the main sections so the design stays self-contained.
-- Link to the supporting references from the main text instead of inlining large snippets.
-- Background research notes and comparisons continue to live in `research.md`, but their conclusions must be summarized in the main design.
+## 補足参照（任意）
+- 情報を本文に置くと可読性を損なう場合（例: 非常に長い TypeScript 定義、ベンダーのオプション比較表、網羅的なスキーマ表）にのみ、このセクションを作る。意思決定の文脈は本文に残し、設計が自己完結するようにする。
+- 大きなスニペットをインライン展開する代わりに、本文からこの補足参照へリンクする。
+- 背景調査のノートや比較は引き続き `research.md` に置くが、その結論は本文の設計に要約しなければならない。

--- a/.kiro/settings/templates/specs/init.json
+++ b/.kiro/settings/templates/specs/init.json
@@ -2,7 +2,7 @@
   "feature_name": "{{FEATURE_NAME}}",
   "created_at": "{{TIMESTAMP}}",
   "updated_at": "{{TIMESTAMP}}",
-  "language": "ja",
+  "language": "{{LANGUAGE}}",
   "phase": "initialized",
   "approvals": {
     "requirements": {
@@ -20,5 +20,3 @@
   },
   "ready_for_implementation": false
 }
-
-

--- a/.kiro/settings/templates/specs/localized-spec-terminology.md
+++ b/.kiro/settings/templates/specs/localized-spec-terminology.md
@@ -1,0 +1,20 @@
+# Localized Spec Terminology
+
+Use this contract whenever a Kiro skill reads, writes, reviews, or validates spec artifacts.
+
+- Newly generated Japanese specs use the Japanese terms from `.kiro/settings/templates/specs`.
+- English specs remain valid and must be treated as alternate accepted terms for `language: "en"`, not deprecated terms. Standard headings within one artifact should follow that artifact's `spec.json.language`; keep code/API/domain identifiers unchanged.
+- Keep diagnostics in the same language family as the artifact whenever possible.
+- Do not translate machine-readable labels: `_Requirements:_`, `_Boundary:_`, and `_Depends:_`.
+
+| Concept | Japanese spec term | English spec term |
+|---------|--------------------|-------------------|
+| Design boundary section | `境界コミットメント` | `Boundary Commitments` |
+| This spec owns subsection | `このスペックが所有するもの` | `This Spec Owns` |
+| Out-of-boundary subsection | `境界外` | `Out of Boundary` |
+| Allowed dependencies subsection | `許可する依存` | `Allowed Dependencies` |
+| Revalidation triggers subsection | `再検証トリガー` | `Revalidation Triggers` |
+| Architecture boundary map subsection | `アーキテクチャパターンと境界マップ` | `Architecture Pattern and Boundary Map` |
+| File structure section | `ファイル構造計画` | `File Structure Plan` |
+| Requirements traceability section | `要件トレーサビリティ` | `Requirements Traceability` |
+| Requirement heading | `### 要件 N:` | `### Requirement N:` |

--- a/.kiro/settings/templates/specs/requirements-init.en.md
+++ b/.kiro/settings/templates/specs/requirements-init.en.md
@@ -1,0 +1,7 @@
+# Requirements
+
+## Project Description (Input)
+{{PROJECT_DESCRIPTION}}
+
+## Requirements
+<!-- Generated during the kiro-spec-requirements phase -->

--- a/.kiro/settings/templates/specs/requirements-init.md
+++ b/.kiro/settings/templates/specs/requirements-init.md
@@ -1,9 +1,7 @@
-# Requirements Document
+# 要件定義
 
-## Project Description (Input)
+## プロジェクト説明（入力）
 {{PROJECT_DESCRIPTION}}
 
-## Requirements
-<!-- Will be generated in /kiro-spec-requirements phase -->
-
-
+## 要件
+<!-- /kiro-spec-requirements フェーズで生成されます -->

--- a/.kiro/settings/templates/specs/requirements.en.md
+++ b/.kiro/settings/templates/specs/requirements.en.md
@@ -1,0 +1,33 @@
+# Requirements
+
+## Introduction
+{{INTRODUCTION}}
+
+<!-- Optional when scope can be misread or adjacent systems/specs may be affected. -->
+## Boundary Context (Optional)
+- **In Scope**: {{IN_SCOPE_BEHAVIORS}}
+- **Out of Scope**: {{OUT_OF_SCOPE_BEHAVIORS}}
+- **Expectations for Adjacent Systems/Specs**: {{ADJACENT_SYSTEM_OR_SPEC_EXPECTATIONS}}
+
+## Requirements
+
+### Requirement 1: {{REQUIREMENT_AREA_1}}
+<!-- Requirement headings must follow the terminology table and use numeric IDs as `Requirement N:` (example: "Requirement 1: ..."). Alphabetic IDs such as "Requirement A" are not allowed. -->
+**Objective:** As a {{ROLE}}, I want {{CAPABILITY}}, so that {{BENEFIT}}.
+
+#### Acceptance Criteria
+<!-- EARS format. English specs use "When", "If", "While", "Where", ubiquitous "shall", and mandatory "shall" wording. -->
+1. When [event], the [system] shall [response/action]
+2. If [trigger/error], the [system] shall [response/action]
+3. While [precondition], the [system] shall [response/action]
+4. Where [feature/option] is included, the [system] shall [response/action]
+5. The [system] shall always [response/action]
+
+### Requirement 2: {{REQUIREMENT_AREA_2}}
+**Objective:** As a {{ROLE}}, I want {{CAPABILITY}}, so that {{BENEFIT}}.
+
+#### Acceptance Criteria
+1. When [event], the [system] shall [response/action]
+2. When [event] and [additional condition], the [system] shall [response/action]
+
+<!-- Continue the same pattern for additional requirements. -->

--- a/.kiro/settings/templates/specs/requirements.md
+++ b/.kiro/settings/templates/specs/requirements.md
@@ -1,32 +1,34 @@
-# Requirements Document
+# 要件定義
 
-## Introduction
+## はじめに
 {{INTRODUCTION}}
 
-<!-- Optional when scope could be misread or the feature touches adjacent systems/specs -->
-## Boundary Context (Optional)
-- **In scope**: {{IN_SCOPE_BEHAVIORS}}
-- **Out of scope**: {{OUT_OF_SCOPE_BEHAVIORS}}
-- **Adjacent expectations**: {{ADJACENT_SYSTEM_OR_SPEC_EXPECTATIONS}}
+<!-- スコープが誤読されうる場合、または隣接するシステム／スペックに影響する場合は任意で記載 -->
+## 境界コンテキスト（任意）
+- **対象範囲**: {{IN_SCOPE_BEHAVIORS}}
+- **対象外**: {{OUT_OF_SCOPE_BEHAVIORS}}
+- **隣接システム／スペックへの期待**: {{ADJACENT_SYSTEM_OR_SPEC_EXPECTATIONS}}
 
-## Requirements
+## 要件
 
-### Requirement 1: {{REQUIREMENT_AREA_1}}
-<!-- Requirement headings MUST include a leading numeric ID only (for example: "Requirement 1: ...", "1. Overview", "2 Feature: ..."). Alphabetic IDs like "Requirement A" are not allowed. -->
-**Objective:** As a {{ROLE}}, I want {{CAPABILITY}}, so that {{BENEFIT}}
+### 要件 1: {{REQUIREMENT_AREA_1}}
+<!-- 要件見出しは用語表の形式に従い、数値IDを `要件 N:` として記載すること（例: "要件 1: ..."）。"要件 A" や "1. 概要" のような形式は不可。 -->
+**目的:** {{ROLE}}として、{{BENEFIT}}のために、{{CAPABILITY}}が欲しい
+<!-- 上記は「[役割]として、[利益]のために、[能力]が欲しい」という形式です。 -->
 
-#### Acceptance Criteria
-1. When [event], the [system] shall [response/action]
-2. If [trigger], then the [system] shall [response/action]
-3. While [precondition], the [system] shall [response/action]
-4. Where [feature is included], the [system] shall [response/action]
-5. The [system] shall [response/action]
+#### 受け入れ基準
+<!-- EARS形式。日本語 spec では `ears-format.md` の固定句に従い、「が起きたとき」「の場合」「の間」「を含む場合」「は常に」と「しなければならない」を用います。 -->
+1. [イベント] が起きたとき、[システム] は [応答／動作] しなければならない
+2. [トリガー／異常] の場合、[システム] は [応答／動作] しなければならない
+3. [前提条件] の間、[システム] は [応答／動作] し続けなければならない
+4. [機能／オプション] を含む場合、[システム] は [応答／動作] しなければならない
+5. [システム] は常に [応答／動作] しなければならない
 
-### Requirement 2: {{REQUIREMENT_AREA_2}}
-**Objective:** As a {{ROLE}}, I want {{CAPABILITY}}, so that {{BENEFIT}}
+### 要件 2: {{REQUIREMENT_AREA_2}}
+**目的:** {{ROLE}}として、{{BENEFIT}}のために、{{CAPABILITY}}が欲しい
 
-#### Acceptance Criteria
-1. When [event], the [system] shall [response/action]
-2. When [event] and [condition], the [system] shall [response/action]
+#### 受け入れ基準
+1. [イベント] が起きたとき、[システム] は [応答／動作] しなければならない
+2. [イベント] が起き、かつ [条件] の場合、[システム] は [応答／動作] しなければならない
 
-<!-- Additional requirements follow the same pattern -->
+<!-- 以降の要件も同じパターンに従う -->

--- a/.kiro/settings/templates/specs/research.en.md
+++ b/.kiro/settings/templates/specs/research.en.md
@@ -1,0 +1,61 @@
+# Research and Design Decision Template
+
+---
+**Purpose**: Record discovery findings, architecture research, and decision rationale that support the technical design.
+
+**How to use**:
+- Record research activities and outcomes during discovery.
+- Document design tradeoffs that are too detailed for `design.md`.
+- Provide references and rationale for future audit and reuse.
+---
+
+## Summary
+- **Feature**: `<feature-name>`
+- **Discovery Scope**: New feature / enhancement / simple addition / complex integration
+- **Key Findings**:
+  - Finding 1
+  - Finding 2
+  - Finding 3
+
+## Research Log
+Record notable research steps and outcomes. Group entries by topic for readability.
+
+### [Topic or Question]
+- **Context**: What prompted this research?
+- **Sources Consulted**: Links, documentation, API references, benchmarks
+- **Findings**: Concise bullets summarizing what was learned
+- **Implications**: How this affects architecture, contracts, or implementation
+
+_Repeat this subsection for each major topic._
+
+## Architecture Pattern Evaluation
+List candidate patterns or approaches. Use a table when helpful.
+
+| Option | Description | Strengths | Risks / Constraints | Notes |
+|--------|-------------|-----------|---------------------|-------|
+| Hexagonal | Port and adapter abstraction around the core domain | Clear boundaries, testable core | Requires adapter layer setup | Aligns with existing steering principle X |
+
+## Design Decisions
+Record key decisions that affect `design.md`. Focus on choices with meaningful tradeoffs.
+
+### Decision: `<title>`
+- **Context**: Requirement or problem driving the decision
+- **Alternatives Considered**:
+  1. Option A - short description
+  2. Option B - short description
+- **Selected Approach**: What was chosen and how it works
+- **Rationale**: Why this fits the current project context
+- **Tradeoffs**: Benefits and compromises
+- **Follow-up**: Items to verify during implementation or testing
+
+_Repeat this subsection for each decision._
+
+## Risks and Mitigations
+- Risk 1 - proposed mitigation
+- Risk 2 - proposed mitigation
+- Risk 3 - proposed mitigation
+
+## References
+Use canonical links and sources: official docs, standards, ADRs, or internal guidelines.
+- [Title](https://example.com) - short note about relevance
+- ...

--- a/.kiro/settings/templates/specs/research.md
+++ b/.kiro/settings/templates/specs/research.md
@@ -1,61 +1,61 @@
-# Research & Design Decisions Template
+# 調査・設計判断テンプレート
 
 ---
-**Purpose**: Capture discovery findings, architectural investigations, and rationale that inform the technical design.
+**目的**: 技術設計の根拠となる、ディスカバリーの発見・アーキテクチャ調査・意思決定の理由を記録する。
 
-**Usage**:
-- Log research activities and outcomes during the discovery phase.
-- Document design decision trade-offs that are too detailed for `design.md`.
-- Provide references and evidence for future audits or reuse.
+**使い方**:
+- ディスカバリーフェーズで、調査活動とその結果を記録する。
+- `design.md` には詳細すぎる、設計判断のトレードオフを文書化する。
+- 将来の監査や再利用のための参照・根拠を提供する。
 ---
 
-## Summary
-- **Feature**: `<feature-name>`
-- **Discovery Scope**: New Feature / Extension / Simple Addition / Complex Integration
-- **Key Findings**:
-  - Finding 1
-  - Finding 2
-  - Finding 3
+## 要約
+- **機能**: `<feature-name>`
+- **ディスカバリー範囲**: 新規機能 / 拡張 / 単純な追加 / 複雑な統合
+- **主要な発見**:
+  - 発見 1
+  - 発見 2
+  - 発見 3
 
-## Research Log
-Document notable investigation steps and their outcomes. Group entries by topic for readability.
+## 調査ログ
+注目すべき調査ステップとその結果を記録する。読みやすさのため、トピックごとにまとめる。
 
-### [Topic or Question]
-- **Context**: What triggered this investigation?
-- **Sources Consulted**: Links, documentation, API references, benchmarks
-- **Findings**: Concise bullet points summarizing the insights
-- **Implications**: How this affects architecture, contracts, or implementation
+### [トピックまたは問い]
+- **背景**: この調査のきっかけは何か？
+- **参照した情報源**: リンク、ドキュメント、APIリファレンス、ベンチマーク
+- **発見**: 得られた知見を簡潔な箇条書きで要約
+- **含意**: アーキテクチャ・契約・実装にどう影響するか
 
-_Repeat the subsection for each major topic._
+_主要なトピックごとに、このサブセクションを繰り返す。_
 
-## Architecture Pattern Evaluation
-List candidate patterns or approaches that were considered. Use the table format where helpful.
+## アーキテクチャパターン評価
+検討したパターンやアプローチの候補を列挙する。役立つ場合は表形式を用いる。
 
-| Option | Description | Strengths | Risks / Limitations | Notes |
+| 選択肢 | 説明 | 強み | リスク／制約 | メモ |
 |--------|-------------|-----------|---------------------|-------|
-| Hexagonal | Ports & adapters abstraction around core domain | Clear boundaries, testable core | Requires adapter layer build-out | Aligns with existing steering principle X |
+| Hexagonal | コアドメインを囲むポート＆アダプタ抽象 | 境界が明確、コアがテスト可能 | アダプタ層の構築が必要 | 既存のステアリング原則 X に整合 |
 
-## Design Decisions
-Record major decisions that influence `design.md`. Focus on choices with significant trade-offs.
+## 設計判断
+`design.md` に影響する主要な意思決定を記録する。トレードオフの大きい選択に焦点を当てる。
 
-### Decision: `<Title>`
-- **Context**: Problem or requirement driving the decision
-- **Alternatives Considered**:
-  1. Option A — short description
-  2. Option B — short description
-- **Selected Approach**: What was chosen and how it works
-- **Rationale**: Why this approach fits the current project context
-- **Trade-offs**: Benefits vs. compromises
-- **Follow-up**: Items to verify during implementation or testing
+### 判断: `<タイトル>`
+- **背景**: 意思決定を駆動する課題または要件
+- **検討した代替案**:
+  1. 案A — 短い説明
+  2. 案B — 短い説明
+- **採用したアプローチ**: 何を選び、どう機能するか
+- **根拠**: なぜこのアプローチが現在のプロジェクト文脈に適合するか
+- **トレードオフ**: 利点と妥協点
+- **フォローアップ**: 実装・テスト時に検証すべき項目
 
-_Repeat the subsection for each decision._
+_意思決定ごとに、このサブセクションを繰り返す。_
 
-## Risks & Mitigations
-- Risk 1 — Proposed mitigation
-- Risk 2 — Proposed mitigation
-- Risk 3 — Proposed mitigation
+## リスクと緩和策
+- リスク 1 — 提案する緩和策
+- リスク 2 — 提案する緩和策
+- リスク 3 — 提案する緩和策
 
-## References
-Provide canonical links and citations (official docs, standards, ADRs, internal guidelines).
-- [Title](https://example.com) — brief note on relevance
+## 参考資料
+正規のリンクと出典を示す（公式ドキュメント、標準仕様、ADR、社内ガイドライン）。
+- [タイトル](https://example.com) — 関連性についての短いメモ
 - ...

--- a/.kiro/settings/templates/specs/tasks.en.md
+++ b/.kiro/settings/templates/specs/tasks.en.md
@@ -1,0 +1,29 @@
+# Implementation Plan
+
+## Task Format Template
+
+Use this canonical annotation grammar for every executable task.
+
+### Main Task With Executable Work
+- [ ] {{NUMBER}}. {{TASK_DESCRIPTION}}{{PARALLEL_MARK}}
+  - {{OBSERVABLE_COMPLETION_ITEM}} *(describe the observable completion signal for this task)*
+  - _Requirements:_ {{REQUIREMENT_IDS}} *(IDs only; do not add descriptions or parentheses)*
+  - _Boundary:_ {{COMPONENT_NAMES}}
+  - _Depends:_ {{TASK_IDS_OR_NONE}}
+
+### Main Task and Subtask Structure
+- [ ] {{MAJOR_NUMBER}}. {{MAJOR_TASK_SUMMARY}}
+- [ ] {{MAJOR_NUMBER}}.{{SUB_NUMBER}} {{SUB_TASK_DESCRIPTION}}{{SUB_PARALLEL_MARK}}
+  - {{DETAIL_ITEM_1}}
+  - {{OBSERVABLE_COMPLETION_ITEM}} *(describe the observable completion signal for this task)*
+  - _Requirements:_ {{REQUIREMENT_IDS}} *(IDs only; do not add descriptions or parentheses)*
+  - _Boundary:_ {{COMPONENT_NAMES}}
+  - _Depends:_ {{TASK_IDS_OR_NONE}}
+
+## Annotation Rules
+
+- `_Requirements:_ {{REQUIREMENT_IDS}}` uses numeric requirement IDs.
+- `_Boundary:_ {{COMPONENT_NAMES}}` names the owning component or workflow boundary.
+- `_Depends:_ {{TASK_IDS_OR_NONE}}` uses task IDs when dependencies exist.
+- `_Depends:_ none` is the canonical syntax when there is no dependency.
+- Add ` (P)` only when boundaries do not overlap and the explicit dependency graph shows the task can run independently.

--- a/.kiro/settings/templates/specs/tasks.md
+++ b/.kiro/settings/templates/specs/tasks.md
@@ -1,24 +1,29 @@
-# Implementation Plan
+# 実装計画
 
-## Task Format Template
+## タスク形式テンプレート
 
-Use whichever pattern fits the work breakdown:
+実行可能なすべてのタスク（every executable task / すべての executable task）に、この正規の注釈文法を用いること。
 
-### Major task only
+### 実行作業を含むメインタスク
 - [ ] {{NUMBER}}. {{TASK_DESCRIPTION}}{{PARALLEL_MARK}}
-  - {{DETAIL_ITEM_1}} *(Include details only when needed. If the task stands alone, omit bullet items.)*
-  - _Requirements: {{REQUIREMENT_IDS}}_
+  - {{OBSERVABLE_COMPLETION_ITEM}} *(このタスクの、観測可能な完了シグナルを具体的に記述する)*
+  - _Requirements:_ {{REQUIREMENT_IDS}} *(IDのみ。説明や括弧を付けない)*
+  - _Boundary:_ {{COMPONENT_NAMES}}
+  - _Depends:_ {{TASK_IDS_OR_NONE}}
 
-### Major + Sub-task structure
+### メインタスクとサブタスク構造
 - [ ] {{MAJOR_NUMBER}}. {{MAJOR_TASK_SUMMARY}}
 - [ ] {{MAJOR_NUMBER}}.{{SUB_NUMBER}} {{SUB_TASK_DESCRIPTION}}{{SUB_PARALLEL_MARK}}
   - {{DETAIL_ITEM_1}}
-  - {{DETAIL_ITEM_2}}
-  - {{OBSERVABLE_COMPLETION_ITEM}} *(At least one detail item should state the observable completion condition for this task.)*
-  - _Requirements: {{REQUIREMENT_IDS}}_ *(IDs only; do not add descriptions or parentheses.)*
-  - _Boundary: {{COMPONENT_NAMES}}_ *(Only for (P) tasks. Omit when scope is obvious.)*
-  - _Depends: {{TASK_IDS}}_ *(Only for non-obvious cross-boundary dependencies. Most tasks omit this.)*
+  - {{OBSERVABLE_COMPLETION_ITEM}} *(このタスクの、観測可能な完了シグナルを具体的に記述する)*
+  - _Requirements:_ {{REQUIREMENT_IDS}} *(IDのみ。説明や括弧を付けない)*
+  - _Boundary:_ {{COMPONENT_NAMES}}
+  - _Depends:_ {{TASK_IDS_OR_NONE}}
 
-> **Parallel marker**: Append ` (P)` only to tasks that can be executed in parallel. Omit the marker when running in `--sequential` mode.
->
-> **Optional test coverage**: When a sub-task is deferrable test work tied to acceptance criteria, mark the checkbox as `- [ ]*` and explain the referenced requirements in the detail bullets.
+## 注釈ルール
+
+- `_Requirements:_ {{REQUIREMENT_IDS}}` には数値の要件IDを用いる。
+- `_Boundary:_ {{COMPONENT_NAMES}}` は、所有するコンポーネントまたはワークフローの境界を示す。
+- `_Depends:_ {{TASK_IDS_OR_NONE}}` は、依存がある場合にタスクIDを用いる。
+- 依存がない場合は `_Depends:_ none` が正規の文法。
+- ` (P)` は、境界が重複せず、かつ明示的な依存グラフ上で独立実行可能と示される場合にのみ付与する。

--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -1,0 +1,7 @@
+#fix: update TAKT-SDD slides with revised event details and contributor info- Updated event title and version for accuracy.
+- Added contributor details highlighting key contributions to TAKT.!/usr/bin/env bash
+
+export CLAUDE_CONFIG_DIR="${HOME}/.claude"
+unset CLAUDE_CODE_OAUTH_TOKEN
+
+exec mise exec -- claude --dangerously-skip-permissions "$@"

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export CLAUDE_IDENTITY="personal"
+export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
+unset CLAUDE_CODE_OAUTH_TOKEN
+
+exec mise exec -- claude --dangerously-skip-permissions "$@"

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export CODEX_HOME="${HOME}/.codex-corporate"
+mkdir -p "${CODEX_HOME}"
+exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export CODEX_HOME="${HOME}/.codex-personal"
+mkdir -p "${CODEX_HOME}"
+exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide changes to how specs are generated and reviewed could shift agent behavior; one launcher script appears to include accidental text on its first line.
> 
> **Overview**
> Aligns the Kiro spec pipeline with **bilingual artifacts** driven by `spec.json.language`, using a shared **`localized-spec-terminology.md`** contract so review, design, requirements, tasks, and validation refer to the correct section names (e.g. boundary and file-structure headings) in Japanese or English.
> 
> **Skills and gates** now pick **language-specific templates** (`*.en.md` vs Japanese defaults), stop on missing/unsupported language, and tighten **tasks** (localized task text, **`_Boundary:_` / `_Depends:_` on every executable task**, `_Depends:_ none` when appropriate). **EARS** rules favor Japanese fixed phrases for `ja` specs while still accepting legacy hybrid English triggers in review.
> 
> **Templates** add English variants for design, requirements, research, and tasks; the Japanese **design** template is fully localized; **`init.json`** uses `{{LANGUAGE}}`** with detection defaulting to **`ja`** when uncertain. Mirrored updates appear under **`.agents/skills`** and **`.claude/skills`**. Small **runner scripts** for corporate/personal Claude/Codex are added (note: `run-claude-corporate.sh` has a corrupted first line in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949af3780d230d9000124eb72e9c595054d9bd31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->