### PR TITLE
fix(ci): takt-skill-auto-update のPR作成失敗からの自動復旧

### DIFF
--- a/.github/workflows/takt-skill-auto-update.yml
+++ b/.github/workflows/takt-skill-auto-update.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Detect new takt tag
         id: compare
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # pre-release タグ（v0.45.0-rc.1 等)を除外し、安定版タグのみを対象にする
           NEW_VERSION=$(git ls-remote --tags https://github.com/nrslib/takt.git 'v*' \
@@ -47,12 +49,15 @@ jobs:
           if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "$OLD_VERSION" ]; then
             echo "新しいタグはありません。スキップします"
             echo "should_update=false" >> "$GITHUB_OUTPUT"
-          # 既存の更新ブランチが NEW_VERSION を反映済みの場合のみスキップする
-          # （クローズ済みPRの再作成防止）。古いパッチ版のままのブランチは
-          # スキップせず、後続の create-pull-request が同一ブランチ・PRを更新する。
+          # 既存の更新ブランチが NEW_VERSION を反映済みで、かつそのブランチの PR が
+          # 一度でも作られている場合のみスキップする（クローズ済みPRの再作成防止）。
+          # push 成功後に PR 作成だけが失敗したブランチ（PR が存在しない）は
+          # スキップせず再実行し、PR 作成を完了させる。古いパッチ版のままの
+          # ブランチもスキップせず、create-pull-request が同一ブランチ・PRを更新する。
           # pipefail 環境でも誤判定しないよう、パイプを使わず文字列照合する。
           elif git fetch --depth 1 origin "$BRANCH" 2>/dev/null \
-            && [[ "$(git show FETCH_HEAD:plugins/takt/skills/takt-skill-updater/SKILL.md 2>/dev/null || true)" == *"前提 takt バージョン**: ${NEW_VERSION}"* ]]; then
+            && [[ "$(git show FETCH_HEAD:plugins/takt/skills/takt-skill-updater/SKILL.md 2>/dev/null || true)" == *"前提 takt バージョン**: ${NEW_VERSION}"* ]] \
+            && [ "$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH&state=all" --jq 'length')" -gt 0 ]; then
             echo "更新ブランチ $BRANCH は既に ${NEW_VERSION} を反映済みのためスキップします"
             echo "should_update=false" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## 概要

初回実行（run 27319279354）で、Claude実行・Verify・ブランチpushまで成功した後、PR作成だけが `Resource not accessible by personal access token` で失敗した。この状態になると check ジョブが「更新ブランチは NEW_VERSION 反映済み」と判定して以降の実行を永久にスキップし、PRが作られないままになる穴があった。

## 変更内容

スキップ条件に「該当ブランチのPRが一度でも作られていること」を追加（`gh api` で `state=all` のPR数を確認）:

- ブランチ反映済み＋PR存在（open/closed/merged）→ スキップ（従来どおりクローズ済みPRの再作成防止）
- ブランチ反映済み＋**PRが一度も存在しない**（push後にPR作成だけ失敗）→ 続行して create-pull-request がPR作成を完了させる
- gh api が失敗した場合は安全側（続行）に倒れる

## 検証

- YAML構文チェック済み
- 実データで判定確認: `chore/update-takt-skills-for-v045`（PR作成失敗状態）→ 0件で続行判定、`feat/takt-skill-auto-update`（マージ済みPR #35）→ 1件でスキップ判定

## 備考

根本原因の `PERSONAL_ACCESS_TOKEN` には Pull requests: Read and write 権限の追加が別途必要。権限追加とこのPRのマージ後、workflow_dispatch を再実行すれば v0.45.0 のPR作成が完了する。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/j5ik2o/ai-tools/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to skip logic in the takt skill update workflow; no runtime or application code affected.
> 
> **Overview**
> Fixes a stuck state in **`takt-skill-auto-update`** where the update branch already reflected the new takt version but **no PR was ever created** (e.g. push succeeded, PR step failed on token permissions). The check job used to skip whenever the branch matched `NEW_VERSION`, so later runs never retried PR creation.
> 
> The **compare** step now sets **`GH_TOKEN`** for `gh` and only skips when the remote branch is up to date **and** `gh api` finds at least one PR for that head (`state=all`). If the branch is current but PR count is zero, **`should_update` stays true** so the workflow can finish opening the PR. Comments document this vs. still skipping when a PR already existed (including closed) to avoid reopening duplicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097e5c8a7b259814f450d689580836aedbb86233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->