### PR TITLE
chore(marketplace): update package refs to the merged plugins commit

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -21,8 +21,8 @@
         "type": "github",
         "repository": "j5ik2o/ai-tools",
         "path": "plugins/git",
-        "ref": "9125e455767663b15bf66f18f32e6f2e56cb97ad",
-        "commit": "9125e455767663b15bf66f18f32e6f2e56cb97ad"
+        "ref": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb",
+        "commit": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb"
       }
     },
     {
@@ -36,8 +36,8 @@
         "type": "github",
         "repository": "j5ik2o/ai-tools",
         "path": "plugins/github",
-        "ref": "9125e455767663b15bf66f18f32e6f2e56cb97ad",
-        "commit": "9125e455767663b15bf66f18f32e6f2e56cb97ad"
+        "ref": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb",
+        "commit": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb"
       }
     },
     {
@@ -50,8 +50,8 @@
         "type": "github",
         "repository": "j5ik2o/ai-tools",
         "path": "plugins/agent-skills",
-        "ref": "9125e455767663b15bf66f18f32e6f2e56cb97ad",
-        "commit": "9125e455767663b15bf66f18f32e6f2e56cb97ad"
+        "ref": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb",
+        "commit": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb"
       }
     },
     {
@@ -65,8 +65,8 @@
         "type": "github",
         "repository": "j5ik2o/ai-tools",
         "path": "plugins/takt",
-        "ref": "9125e455767663b15bf66f18f32e6f2e56cb97ad",
-        "commit": "9125e455767663b15bf66f18f32e6f2e56cb97ad"
+        "ref": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb",
+        "commit": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb"
       }
     },
     {
@@ -80,8 +80,8 @@
         "type": "github",
         "repository": "j5ik2o/ai-tools",
         "path": "plugins/software-design",
-        "ref": "9125e455767663b15bf66f18f32e6f2e56cb97ad",
-        "commit": "9125e455767663b15bf66f18f32e6f2e56cb97ad"
+        "ref": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb",
+        "commit": "d5b8e5db93fdf0446fcfb937ecbc0e12030740cb"
       }
     }
   ]

--- a/marketplace.yml
+++ b/marketplace.yml
@@ -11,7 +11,7 @@ packages:
     description: Git workflow skills, including staging and committing working-tree changes following Conventional Commits.
     source: j5ik2o/ai-tools
     subdir: plugins/git
-    ref: 9125e455767663b15bf66f18f32e6f2e56cb97ad
+    ref: d5b8e5db93fdf0446fcfb937ecbc0e12030740cb
     tags:
       - development
       - git
@@ -20,7 +20,7 @@ packages:
     description: GitHub workflow skills, including systematic issue triage, grouping, prioritization, and cleanup.
     source: j5ik2o/ai-tools
     subdir: plugins/github
-    ref: 9125e455767663b15bf66f18f32e6f2e56cb97ad
+    ref: d5b8e5db93fdf0446fcfb937ecbc0e12030740cb
     tags:
       - development
       - github
@@ -29,7 +29,7 @@ packages:
     description: Collection of agent skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling.
     source: j5ik2o/ai-tools
     subdir: plugins/agent-skills
-    ref: 9125e455767663b15bf66f18f32e6f2e56cb97ad
+    ref: d5b8e5db93fdf0446fcfb937ecbc0e12030740cb
     tags:
       - development
       - skills
@@ -37,7 +37,7 @@ packages:
     description: TAKT workflow engine skills for multi-agent orchestration. Includes analyzers, builders, and optimizers for TAKT workflow YAML.
     source: j5ik2o/ai-tools
     subdir: plugins/takt
-    ref: 9125e455767663b15bf66f18f32e6f2e56cb97ad
+    ref: d5b8e5db93fdf0446fcfb937ecbc0e12030740cb
     tags:
       - development
       - workflow
@@ -46,7 +46,7 @@ packages:
     description: Software design skills for DDD, clean architecture, error handling, package design, refactoring, and maintainable domain modeling.
     source: j5ik2o/ai-tools
     subdir: plugins/software-design
-    ref: 9125e455767663b15bf66f18f32e6f2e56cb97ad
+    ref: d5b8e5db93fdf0446fcfb937ecbc0e12030740cb
     tags:
       - development
       - software-design


### PR DESCRIPTION
## 概要

PR #45 で追加した `git` / `github` プラグインを APM が解決できるよう、`marketplace.yml` の全パッケージの `ref` をマージコミット `d5b8e5d` に更新する。

## 背景

- 旧 `ref` `9125e45` は `plugins/git` / `plugins/github` を含まないコミットを指しており、APM で `git@ai-tools` / `github@ai-tools` を解決すると subdir が存在せずインストールできなかった（issue #46）。
- 既存パッケージはすべて単一の共有 ref を使う設計のため、git/github だけ更新すると ref が分裂する。整合性維持のため全 5 パッケージを `d5b8e5d` に揃える。
- これにより、PR #45 で修正した takt の説明（piece → workflow）も APM 消費者に反映される。

## 変更

- `marketplace.yml`: 全 5 パッケージの `ref` を `9125e45` → `d5b8e5d`
- `marketplace.json`: `mise run apm:marketplace:build` で再生成

## 検証

- マージコミット `d5b8e5d` に全プラグインの subdir が存在することを確認（git/github/agent-skills/takt/software-design）
- `claude plugin validate .` 通過（warning は version 未指定のみ、既存規約どおり）
- 生成 `marketplace.json` の全 ref が `d5b8e5d` に更新されていることを確認

Closes #46

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only ref pin updates with no application logic changes; main risk is consumers pinning to a commit that must include all listed plugin paths.
> 
> **Overview**
> **Aligns every marketplace package on a single Git ref** so APM can resolve `git` and `github` (and the rest) from commits that actually contain their `plugins/*` subdirs.
> 
> `marketplace.yml` updates all five packages from `9125e45…` to merge commit `d5b8e5d…`. `marketplace.json` is regenerated so each plugin’s `source.ref` and `source.commit` match that same hash—fixing installs that failed when the old ref pointed at a tree without `plugins/git` / `plugins/github`, and keeping one shared ref instead of splitting versions across packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161390dc31be0fbe345fc022895311714cee4cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->