### PR TITLE
READMEにgh skillでのインストール方法を追加

### DIFF
--- a/.agents/skills/deep-research-read-me
+++ b/.agents/skills/deep-research-read-me
@@ -1,0 +1,1 @@
+../../plugins/github/skills/deep-research-read-me

--- a/.claude/skills/deep-research-read-me
+++ b/.claude/skills/deep-research-read-me
@@ -1,0 +1,1 @@
+../../plugins/github/skills/deep-research-read-me

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A marketplace repository for distributing AI agent skills for Claude Code and sk
 - Publishes multiple plugins through `.claude-plugin/marketplace.json`
 - Provides an APM marketplace manifest through `marketplace.yml` and generated `marketplace.json`
 - Includes installable skill collections such as `agent-skills`, `takt`, and `software-design`
-- Keeps `skills/` symlinks for tools that consume plain skill directories directly
+- Keeps `skills/`, `.agents/skills/`, and `.claude/skills/` links for tools that consume plain skill directories directly
 
 ## Installation
 
@@ -33,6 +33,24 @@ apm install software-design@ai-tools
 
 Available APM package names are `git`, `github`, `agent-skills`, `takt`, and `software-design`.
 
+### GitHub CLI Skill
+
+GitHub CLI provides `gh skill` for installing agent skills from GitHub repositories. See the [`gh skill` manual](https://cli.github.com/manual/gh_skill) for the current preview behavior.
+
+Install a specific skill from this repository:
+
+```shell
+gh skill install j5ik2o/ai-tools deep-research-read-me --agent codex --scope user --pin main
+```
+
+Install every skill exposed through the standard `skills/` directory:
+
+```shell
+gh skill install j5ik2o/ai-tools --all --agent codex --scope user --pin main
+```
+
+The `skills/` directory is the default discovery entry point. Mirrored links are also kept under `.agents/skills/` and `.claude/skills/`; pass `--allow-hidden-dirs` only when you intentionally want `gh skill` to include hidden skill directories during discovery.
+
 ### Skill-directory-based CLI
 
 ```shell
@@ -44,7 +62,7 @@ npx skills add j5ik2o/ai-tools
 | Plugin | Description | Key skills | Details |
 |--------|-------------|------------|---------|
 | [`git`](plugins/git) | Git workflow skills, including staging and committing working-tree changes following Conventional Commits | [`git-commit`](plugins/git/skills/git-commit) | [plugin.json](plugins/git/.claude-plugin/plugin.json) |
-| [`github`](plugins/github) | GitHub workflow skills, including systematic issue triage, grouping, prioritization, and cleanup | [`gh-issue-organizer`](plugins/github/skills/gh-issue-organizer) | [plugin.json](plugins/github/.claude-plugin/plugin.json) |
+| [`github`](plugins/github) | GitHub workflow skills, including systematic issue triage and GitHub OSS README creation, improvement, and review | [`gh-issue-organizer`](plugins/github/skills/gh-issue-organizer), [`deep-research-read-me`](plugins/github/skills/deep-research-read-me) | [plugin.json](plugins/github/.claude-plugin/plugin.json) |
 | [`agent-skills`](plugins/agent-skills) | Agent skills demonstrating skill creation, evaluation, and iterative improvement workflows | [`skill-forge`](plugins/agent-skills/skills/skill-forge) | [README](plugins/agent-skills/README.md) |
 | [`takt`](plugins/takt) | TAKT workflow engine skills for multi-agent orchestration, analysis, building, and optimization | `takt-task-builder`, `takt-workflow-builder`, `takt-facet-builder`, `takt-analyzer`, `takt-optimizer`, `takt-skill-updater` | [README](plugins/takt/README.md) |
 | [`software-design`](plugins/software-design) | Software design skills for DDD, clean architecture, error handling, package design, refactoring, and maintainable domain modeling | `ddd-aggregate-design`, `clean-architecture`, `error-handling`, `package-design`, `refactoring-packages` | [plugin.json](plugins/software-design/.claude-plugin/plugin.json) |
@@ -65,6 +83,7 @@ plugins/
 │       └── git-commit/
 ├── github/
 │   └── skills/
+│       ├── deep-research-read-me/
 │       └── gh-issue-organizer/
 ├── agent-skills/
 │   ├── README.md
@@ -86,8 +105,17 @@ plugins/
         └── ...
 
 skills/
+├── deep-research-read-me -> ../plugins/github/skills/deep-research-read-me
 ├── skill-forge -> ../plugins/agent-skills/skills/skill-forge
 ├── takt-analyzer -> ../plugins/takt/skills/takt-analyzer
+└── ...
+
+.agents/skills/
+├── deep-research-read-me -> ../../plugins/github/skills/deep-research-read-me
+└── ...
+
+.claude/skills/
+├── deep-research-read-me -> ../../plugins/github/skills/deep-research-read-me
 └── ...
 
 template/

--- a/skills/deep-research-read-me
+++ b/skills/deep-research-read-me
@@ -1,0 +1,1 @@
+../plugins/github/skills/deep-research-read-me


### PR DESCRIPTION
## 概要
- README.md に `gh skill install` を使ったインストール方法を追加
- `deep-research-read-me` を `skills/`、`.agents/skills/`、`.claude/skills/` から参照できるよう symlink を追加
- README の GitHub プラグイン説明とリポジトリ構造例を最新化

## 検証
- `git diff --check`
- `gh skill install . deep-research-read-me --from-local --dir /tmp/ai-tools-gh-skill-test`
- 追加した symlink それぞれから `SKILL.md` を参照できることを確認

## 参考
- https://cli.github.com/manual/gh_skill

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and symlink-only changes with no runtime or security-sensitive code paths.
> 
> **Overview**
> Documents **GitHub CLI `gh skill install`** as a new installation path, with examples for installing a single skill (`deep-research-read-me`) or all skills under `skills/`, plus a note on `--allow-hidden-dirs` for `.agents/skills/` and `.claude/skills/`.
> 
> **Symlinks** expose `plugins/github/skills/deep-research-read-me` from `skills/`, `.agents/skills/`, and `.claude/skills/` so discovery tools can resolve the skill without plugin packaging.
> 
> README **highlights**, the **github** plugin row, and the **repository structure** tree are updated to mention the mirrored skill directories and the new README-focused skill alongside `gh-issue-organizer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4ee81f454b1afb54f95ed1bc820f8fd7335dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->