### PR TITLE
[codex] Align skill-forge with Claude Code and Codex skill specs

### DIFF
--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -49,6 +49,8 @@ Read only the reference files needed for the current branch:
   evals with the user.
 - `references/openai_yaml.md` - read before generating or reviewing Codex
   `agents/openai.yaml` metadata.
+- `references/skill_creator_comparison.md` - read before updating platform
+  assumptions or comparing skill-forge against Anthropic/OpenAI creator flows.
 - `references/trigger_eval_boundaries.md` - read before changing trigger eval
   parsing or interpreting surprising Claude Code / Codex CLI trigger results.
 - `references/schemas.md` - read before writing or manually inspecting

--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -91,6 +91,8 @@ skill-name/
 ├── SKILL.md (required)
 │   ├── YAML frontmatter (name, description required)
 │   └── Markdown instructions
+├── agents/
+│   └── openai.yaml - Codex UI metadata, invocation policy, and tool dependencies
 └── Bundled Resources (optional)
     ├── scripts/    - Executable code for deterministic/repetitive tasks
     ├── references/ - Docs loaded into context as needed
@@ -192,15 +194,24 @@ If `uv` is not installed, direct the user to https://docs.astral.sh/uv/ — it's
 
 ## Validating skills
 
+For Codex-compatible skills, read `references/openai_yaml.md` before generating or reviewing `agents/openai.yaml`.
+
+Generate Codex UI metadata after the target skill has a stable `SKILL.md` frontmatter:
+
+```bash
+uv run python scripts/generate_openai_yaml.py <skill-dir>
+```
+
 Use `scripts/quick_validate.py` before packaging or publishing a skill. The validator supports platform-specific checks:
 
 ```bash
 uv run python scripts/quick_validate.py <skill-dir>                  # auto: accepts Claude/Codex frontmatter and validates agents/openai.yaml if present
 uv run python scripts/quick_validate.py <skill-dir> --platform claude
 uv run python scripts/quick_validate.py <skill-dir> --platform codex
+uv run python scripts/quick_validate.py <skill-dir> --platform codex --strict-openai-yaml
 ```
 
-Use `--platform claude` when checking Claude Code-only frontmatter such as `disable-model-invocation`, `user-invocable`, or `when_to_use`. Use `--platform codex` when checking Codex skills and `agents/openai.yaml` metadata.
+Use `--platform claude` when checking Claude Code-only frontmatter such as `disable-model-invocation`, `user-invocable`, or `when_to_use`. Use `--platform codex` when checking Codex skills and `agents/openai.yaml` metadata. Use `--strict-openai-yaml` before publishing Codex metadata; it requires `display_name`, `short_description`, and `default_prompt`, and detects stale metadata after `SKILL.md` changes.
 
 ## Running and evaluating test cases
 

--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -462,6 +462,8 @@ This step matters — bad eval queries lead to bad descriptions.
 
 Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
 
+Before changing trigger eval parsing or interpreting surprising trigger results, read `references/trigger_eval_boundaries.md`. It documents the Claude Code and Codex CLI detector signals, false positive/false negative boundaries, and the difference between a successful non-trigger and zero successful runs.
+
 Save the eval set to the workspace, then run in the background:
 
 **Claude Code:**
@@ -495,6 +497,8 @@ The same CLI selection is used for both evaluation and description improvement. 
 While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
 
 This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude with extended thinking to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+If a query result has `status: "error"` or `status: "not_run"`, treat it as eval infrastructure failure, not as evidence that the skill failed to trigger. A successful non-trigger has `status: "ok"`, `runs > 0`, and `triggers == 0`.
 
 ### How skill triggering works
 

--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -19,456 +19,178 @@ description: >-
 
 # Skill Forge
 
-A skill for creating new skills and iteratively improving them.
+Use this skill to create, test, improve, package, and maintain Claude Code and
+Codex skills.
 
-At a high level, the process of creating a skill goes like this:
+The default loop is:
 
-- Decide what you want the skill to do and roughly how it should do it
-- Write a draft of the skill
-- Create a few test prompts and run claude-with-access-to-the-skill on them
-- Help the user evaluate the results both qualitatively and quantitatively
-  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
-  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
-- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
-- Repeat until you're satisfied
-- Expand the test set and try again at larger scale
+1. Understand the intended skill boundary.
+2. Draft or edit `SKILL.md`.
+3. Create realistic eval prompts.
+4. Run the skill and an appropriate baseline.
+5. Grade, aggregate, and show the user the viewer.
+6. Improve from feedback and repeat.
+7. Optionally optimize the frontmatter description and package the skill.
 
-Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+If the user only wants brainstorming, skip evals and act as a design partner.
+If the user already has a draft, start at validation, evals, or iteration.
 
-On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+## Progressive disclosure map
 
-Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+Read only the reference files needed for the current branch:
 
-Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+- `references/skill_authoring.md` - read before drafting or reviewing a
+  `SKILL.md`, especially when the body may approach 500 lines.
+- `references/eval_workflow.md` - read before running test cases, benchmarks,
+  grading, viewer generation, blind comparison, or iteration from feedback.
+- `references/description_optimization.md` - read before optimizing or debugging
+  a skill's trigger description. It requires you to read the target skill's `SKILL.md`,
+  extracting `helps with` and `should not help with`, then reviewing trigger
+  evals with the user.
+- `references/openai_yaml.md` - read before generating or reviewing Codex
+  `agents/openai.yaml` metadata.
+- `references/trigger_eval_boundaries.md` - read before changing trigger eval
+  parsing or interpreting surprising Claude Code / Codex CLI trigger results.
+- `references/schemas.md` - read before writing or manually inspecting
+  `evals.json`, `eval_metadata.json`, `grading.json`, or `benchmark.json`.
+- `references/platform_notes.md` - read when running in Claude.ai, Cowork, or a
+  headless environment.
 
-Cool? Cool.
+The `agents/` directory contains specialized subagent instructions:
+
+- `agents/grader.md` - how to evaluate expectations against outputs.
+- `agents/comparator.md` - how to do blind A/B comparison.
+- `agents/analyzer.md` - how to analyze benchmark results.
 
 ## Communicating with the user
 
-The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+Skill Forge may be used by people with very different levels of coding
+familiarity. Match the user's vocabulary. In the default case, terms like
+"evaluation" and "benchmark" are OK, while "JSON" and "expectation" may need a
+short definition.
 
-So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+Explain tradeoffs plainly. Ask for confirmation before running an expensive eval
+loop, changing trigger behavior, or packaging a skill.
 
-- "evaluation" and "benchmark" are borderline, but OK
-- for "JSON" and "expectation" you want to see serious cues from the user that they know what those things are before using them without explaining them
+## Creating or editing a skill
 
-It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+Start by extracting what the conversation already tells you. If the user says
+"turn this into a skill", reuse the observed workflow, tools, corrections,
+inputs, and outputs before asking more questions.
 
----
+Clarify these points:
 
-## Creating a skill
+1. What should the skill enable the agent to do?
+2. When should the skill trigger?
+3. What output should it produce?
+4. Should the skill be Claude-only, Codex-only, or compatible with both?
+5. Should evals be added now?
 
-### Capture Intent
+When drafting, read `references/skill_authoring.md`. At minimum, produce:
 
-Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+- `name`: stable skill identifier.
+- `description`: the trigger boundary. Put all "when to use" guidance here.
+- `compatibility`: optional requirements, only when useful.
+- Body instructions: the durable workflow and pointers to bundled resources.
 
-1. What should this skill enable Claude to do?
-2. When should this skill trigger? (what user phrases/contexts)
-3. What's the expected output format?
-4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+Descriptions should be direct and a little pushy for true positives, because
+skills can under-trigger. Also include explicit exclusions for near misses so the
+skill does not hijack ordinary coding, docs, or operations work.
 
-### Interview and Research
-
-Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
-
-Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
-
-### Write the SKILL.md
-
-Based on the user interview, fill in these components:
-
-- **name**: Skill identifier
-- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
-- **compatibility**: Required tools, dependencies (optional, rarely needed)
-- **the rest of the skill :)**
-
-### Skill Writing Guide
-
-#### Anatomy of a Skill
-
-```
-skill-name/
-├── SKILL.md (required)
-│   ├── YAML frontmatter (name, description required)
-│   └── Markdown instructions
-├── agents/
-│   └── openai.yaml - Codex UI metadata, invocation policy, and tool dependencies
-└── Bundled Resources (optional)
-    ├── scripts/    - Executable code for deterministic/repetitive tasks
-    ├── references/ - Docs loaded into context as needed
-    └── assets/     - Files used in output (templates, icons, fonts)
-```
-
-#### Progressive Disclosure
-
-Skills use a three-level loading system:
-1. **Metadata** (name + description) - Always in context (~100 words)
-2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
-3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
-
-These word counts are approximate and you can feel free to go longer if needed.
-
-**Key patterns:**
-- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
-- Reference files clearly from SKILL.md with guidance on when to read them
-- For large reference files (>300 lines), include a table of contents
-
-**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
-```
-cloud-deploy/
-├── SKILL.md (workflow + selection)
-└── references/
-    ├── aws.md
-    ├── gcp.md
-    └── azure.md
-```
-Claude reads only the relevant reference file.
-
-#### Principle of Lack of Surprise
-
-This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
-
-#### Writing Patterns
-
-Prefer using the imperative form in instructions.
-
-**Defining output formats** - You can do it like this:
-```markdown
-## Report structure
-ALWAYS use this exact template:
-# [Title]
-## Executive summary
-## Key findings
-## Recommendations
-```
-
-**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
-```markdown
-## Commit message format
-**Example 1:**
-Input: Added user authentication with JWT tokens
-Output: feat(auth): implement JWT-based authentication
-```
-
-### Writing Style
-
-Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
-
-### Test Cases
-
-After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
-
-Save test cases to `evals/evals.json` inside the skill directory (e.g., `<skill-dir>/evals/evals.json`). This keeps eval definitions co-located with the skill they test. Don't write expectations yet — just the prompts. You'll draft expectations in the next step while the runs are in progress.
-
-```json
-{
-  "skill_name": "example-skill",
-  "evals": [
-    {
-      "id": 1,
-      "prompt": "User's task prompt",
-      "expected_output": "Description of expected result",
-      "files": []
-    }
-  ]
-}
-```
-
-See `references/schemas.md` for the full schema, including the `expectations` field you'll add later.
+After editing `SKILL.md`, validate it and regenerate Codex metadata when present.
 
 ## Python environment setup
 
-Before running any scripts, make sure the Python environment is ready. The scripts depend on packages managed by [uv](https://docs.astral.sh/uv/), and `.venv` is gitignored — so it won't exist in a fresh clone or a git worktree.
-
-Check once before the first script invocation:
+Before running scripts, ensure the Python environment is ready from the
+skill-forge directory:
 
 ```bash
-# from the skill-forge directory
-cd <skill-forge-path>
-uv sync --group dev   # creates .venv if missing, then installs deps
+uv sync --group dev
 ```
 
-After this, use `uv run` for every script call (shown in the examples below). `uv run` re-syncs automatically if the lockfile changes, so you never need to repeat this step.
-
-If `uv` is not installed, direct the user to https://docs.astral.sh/uv/ — it's a one-line install and there's no alternative setup path.
+Use `uv run` for every script call. If `uv` is missing, direct the user to
+https://docs.astral.sh/uv/.
 
 ## Validating skills
 
-For Codex-compatible skills, read `references/openai_yaml.md` before generating or reviewing `agents/openai.yaml`.
+For Codex-compatible skills, read `references/openai_yaml.md` before generating
+or reviewing `agents/openai.yaml`.
 
-Generate Codex UI metadata after the target skill has a stable `SKILL.md` frontmatter:
+Generate Codex UI metadata after the target skill has stable `SKILL.md`
+frontmatter:
 
 ```bash
 uv run python scripts/generate_openai_yaml.py <skill-dir>
 ```
 
-Use `scripts/quick_validate.py` before packaging or publishing a skill. The validator supports platform-specific checks:
+Run validation before packaging or publishing:
 
 ```bash
-uv run python scripts/quick_validate.py <skill-dir>                  # auto: accepts Claude/Codex frontmatter and validates agents/openai.yaml if present
+uv run python scripts/quick_validate.py <skill-dir>
 uv run python scripts/quick_validate.py <skill-dir> --platform claude
 uv run python scripts/quick_validate.py <skill-dir> --platform codex
 uv run python scripts/quick_validate.py <skill-dir> --platform codex --strict-openai-yaml
 ```
 
-Use `--platform claude` when checking Claude Code-only frontmatter such as `disable-model-invocation`, `user-invocable`, or `when_to_use`. Use `--platform codex` when checking Codex skills and `agents/openai.yaml` metadata. Use `--strict-openai-yaml` before publishing Codex metadata; it requires `display_name`, `short_description`, and `default_prompt`, and detects stale metadata after `SKILL.md` changes.
+Use `--platform claude` for Claude Code-only frontmatter such as
+`disable-model-invocation`, `user-invocable`, or `when_to_use`. Use
+`--platform codex` for Codex skills and `agents/openai.yaml`. Use
+`--strict-openai-yaml` before publishing Codex metadata; it requires
+`display_name`, `short_description`, and `default_prompt`, and detects stale
+metadata after `SKILL.md` changes.
 
-## Running and evaluating test cases
+## Evals and benchmarks
 
-This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+Before running evals, read `references/eval_workflow.md`.
 
-Create an isolated workspace directory for the eval runs using `mktemp -d`:
+Core rules:
 
-```bash
-WORKSPACE=$(mktemp -d)
-echo "Workspace: $WORKSPACE"
-```
+- Create an isolated workspace and show the path to the user.
+- For each test case, start the with-skill run and baseline run in the same turn.
+- Run each task in its own working directory under the workspace.
+- Write `eval_metadata.json` for each test case; new files start with
+  `"expectations": []`.
+- Draft expectations while runs are in progress.
+- Save timing data as run notifications arrive.
+- Grade using `agents/grader.md`.
+- Aggregate with `scripts.aggregate_benchmark`.
+- Generate the human review UI with `eval-viewer/generate_review.py`; do not
+  write custom viewer HTML.
+- Read user feedback before revising the skill again.
 
-This ensures a clean, isolated environment for each evaluation run. If you need persistence across sessions (e.g., to resume an interrupted run), you can instead use a fixed path: `.claude/skills-workspaces/<skill-name>/` for Claude Code, or `.codex/skills-workspaces/<skill-name>/` for Codex CLI. These workspace paths are only for eval outputs; Codex skill discovery uses `.agents/skills`, not `.codex/skills`. After creating the workspace, run `ls $WORKSPACE` to verify it exists. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+For schema details, read `references/schemas.md`. Writers must emit
+`expectations`; old `assertions` are only a legacy alias for readers.
 
-**Important: Always display the workspace path to the user** so they can inspect outputs directly. When eval runs complete, also display the full path to each generated output file.
+## Improving a skill
 
-### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+Improve from evidence, not from vibes alone:
 
-For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+- Generalize from user feedback instead of overfitting to one eval prompt.
+- Read transcripts when outputs are surprising.
+- Remove instructions that cause repeated wasted work.
+- Bundle helper scripts when multiple evals reinvent the same deterministic
+  helper.
+- Rerun the eval workflow after meaningful changes.
 
-**Important: Run in isolated directories, not the skill source directory.** Each run must execute in its own isolated working directory under the workspace to avoid polluting the skill source or interfering with other runs.
+For blind A/B comparison, read `agents/comparator.md` and `agents/analyzer.md`.
 
-**With-skill run:**
+## Description optimization
 
-```
-Execute this task:
-- Skill path: <path-to-skill>
-- Task: <eval prompt>
-- Input files: <eval files if any, or "none">
-- Working directory: <workspace>/iteration-<N>/eval-<ID>/with_skill/
-- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
-- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
-```
+After the skill body is stable, offer trigger optimization. Read
+`references/description_optimization.md` before starting.
 
-**Baseline run** (same prompt, but the baseline depends on context):
-- **Creating a new skill**: no skill at all. Same prompt, no skill path, working directory `<workspace>/iteration-<N>/eval-<ID>/without_skill/`, save outputs to `without_skill/outputs/`.
-- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Working directory `<workspace>/iteration-<N>/eval-<ID>/old_skill/`, save outputs to `old_skill/outputs/`.
+Minimum workflow:
 
-Write an `eval_metadata.json` for each test case (`expectations` can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+1. Read the target skill's `SKILL.md`.
+2. Extract `helps with` and `should not help with`.
+3. Draft should-trigger and should-not-trigger queries.
+4. Let the user review the query set with `assets/eval_review.html`.
+5. Run `scripts.run_loop` with the right CLI.
+6. Apply `best_description`, show before/after, and report scores.
 
-```json
-{
-  "eval_id": 0,
-  "eval_name": "descriptive-name-here",
-  "prompt": "The user's task prompt",
-  "expectations": []
-}
-```
-
-### Step 2: While runs are in progress, draft expectations
-
-Don't just wait for the runs to finish — you can use this time productively. Draft quantitative expectations for each test case and explain them to the user. If expectations already exist in `evals/evals.json`, review them and explain what they check.
-
-Good expectations are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force expectations onto things that need human judgment.
-
-Update the `eval_metadata.json` files and `evals/evals.json` with the expectations once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
-
-### Step 3: As runs complete, capture timing data
-
-When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
-
-```json
-{
-  "total_tokens": 84852,
-  "duration_ms": 23332,
-  "total_duration_seconds": 23.3
-}
-```
-
-This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
-
-### Step 4: Grade, aggregate, and launch the viewer
-
-Once all runs are done:
-
-1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each expectation against the outputs. Save results to `grading.json` in each run directory. The `grading.json` expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For expectations that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
-
-2. **Aggregate into benchmark** — run the aggregation script from the skill-forge directory:
-   ```bash
-   cd <skill-forge-path>
-   uv run python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
-   ```
-   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
-Put each with_skill version before its baseline counterpart.
-
-3. **Save benchmark results to the skill folder** — After aggregation, copy the benchmark to the skill's own directory so results are tracked alongside the skill source. `<skill-dir>` is the actual skill source directory (not a symlink or cache path). Note that `<workspace>` varies by CLI: `.claude/skills-workspaces/<skill-name>/` for Claude Code (or `$CLAUDE_CONFIG_DIR/skills-workspaces/<skill-name>/` if set), `.codex/skills-workspaces/<skill-name>/` for Codex CLI (or `$CODEX_HOME/skills-workspaces/<skill-name>/` if set). These are eval result workspaces, not skill discovery directories. Use the same workspace path that was resolved in the "Running and evaluating test cases" section above.
-   ```bash
-   mkdir -p <skill-dir>/evals/benchmarks
-   cp <workspace>/iteration-<N>/benchmark.json \
-      <skill-dir>/evals/benchmarks/$(date +%Y-%m-%d)-iteration-<N>.json
-   ```
-   Then create or update `<skill-dir>/evals/benchmarks/README.md` with a summary table. If the file already exists, append a new row; otherwise create it with a header. The table should include:
-
-   | Iteration | Date | Pass Rate (with skill) | Pass Rate (baseline) | Avg Tokens | Avg Duration |
-   |-----------|------|------------------------|----------------------|------------|--------------|
-
-   Extract the values from `benchmark.json`. This gives the skill a persistent quality record that travels with the source code.
-
-4. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like expectations that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
-
-5. **Launch the viewer** with both qualitative outputs and quantitative data:
-   ```bash
-   nohup uv run --project <skill-forge-path> python <skill-forge-path>/eval-viewer/generate_review.py \
-     <workspace>/iteration-N \
-     --skill-name "my-skill" \
-     --benchmark <workspace>/iteration-N/benchmark.json \
-     > /dev/null 2>&1 &
-   VIEWER_PID=$!
-   ```
-   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
-
-   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
-
-Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
-
-6. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
-
-### What the user sees in the viewer
-
-The "Outputs" tab shows one test case at a time:
-- **Prompt**: the task that was given
-- **Output**: the files the skill produced, rendered inline where possible
-- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
-- **Formal Grades** (if grading was run): collapsed section showing expectation pass/fail
-- **Feedback**: a textbox that auto-saves as they type
-- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
-
-The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
-
-Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
-
-### Step 5: Read the feedback
-
-When the user tells you they're done, read `feedback.json`:
-
-```json
-{
-  "reviews": [
-    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
-    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
-    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
-  ],
-  "status": "complete"
-}
-```
-
-Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
-
-Kill the viewer server when you're done with it:
+Claude Code example:
 
 ```bash
-kill $VIEWER_PID 2>/dev/null
-```
-
----
-
-## Improving the skill
-
-This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
-
-### How to think about improvements
-
-1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
-
-2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
-
-3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
-
-4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
-
-This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
-
-### The iteration loop
-
-After improving the skill:
-
-1. Apply your improvements to the skill
-2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
-3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
-4. Wait for the user to review and tell you they're done
-5. Read the new feedback, improve again, repeat
-
-Keep going until:
-- The user says they're happy
-- The feedback is all empty (everything looks good)
-- You're not making meaningful progress
-
----
-
-## Advanced: Blind comparison
-
-For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
-
-This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
-
----
-
-## Description Optimization
-
-The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
-
-### Step 1: Generate trigger eval queries
-
-Before drafting queries, read the target skill's `SKILL.md` and extract two short lists:
-
-- `helps with`: the user intents and situations the skill is meant to handle
-- `should not help with`: adjacent requests or keywords that look similar but belong to a different skill or a normal coding/docs workflow
-
-Use those lists to keep the eval set anchored to the target skill's actual boundary instead of generic domain keywords.
-
-Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
-
-```json
-[
-  {"query": "the user prompt", "should_trigger": true},
-  {"query": "another prompt", "should_trigger": false}
-]
-```
-
-The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
-
-Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
-
-Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
-
-For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
-
-For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
-
-The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
-
-### Step 2: Review with user
-
-Present the eval set to the user for review using the HTML template:
-
-1. Read the template from `assets/eval_review.html`
-2. Replace the placeholders:
-   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
-   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
-   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
-3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
-4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
-5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
-
-This step matters — bad eval queries lead to bad descriptions.
-
-### Step 3: Run the optimization loop
-
-Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
-
-Before changing trigger eval parsing or interpreting surprising trigger results, read `references/trigger_eval_boundaries.md`. It documents the Claude Code and Codex CLI detector signals, false positive/false negative boundaries, and the difference between a successful non-trigger and zero successful runs.
-
-Save the eval set to the workspace, then run in the background:
-
-**Claude Code:**
-```bash
-cd <skill-forge-path>
 uv run python -m scripts.run_loop \
   --eval-set <path-to-trigger-eval.json> \
   --skill-path <path-to-skill> \
@@ -477,9 +199,9 @@ uv run python -m scripts.run_loop \
   --verbose
 ```
 
-**Codex CLI:**
+Codex CLI example:
+
 ```bash
-cd <skill-forge-path>
 uv run python -m scripts.run_loop \
   --eval-set <path-to-trigger-eval.json> \
   --skill-path <path-to-skill> \
@@ -489,105 +211,40 @@ uv run python -m scripts.run_loop \
   --verbose
 ```
 
-The `--cli` flag selects which CLI to use (`claude` or `codex`). If omitted, the script auto-detects based on which CLI is available in PATH. You can also set the `SKILL_FORGE_EVAL_CLI` environment variable.
+No separate Anthropic API client setup is required for the optimization loop.
+Before interpreting `status: "error"` or `status: "not_run"`, read
+`references/trigger_eval_boundaries.md`.
 
-Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
-The same CLI selection is used for both evaluation and description improvement. No separate Anthropic API client setup is required for the optimization loop.
+## Platform-specific branches
 
-While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+For Claude.ai, Cowork, and headless environments, read
+`references/platform_notes.md` before adapting the workflow.
 
-This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude with extended thinking to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+Short version:
 
-If a query result has `status: "error"` or `status: "not_run"`, treat it as eval infrastructure failure, not as evidence that the skill failed to trigger. A successful non-trigger has `status: "ok"`, `runs > 0`, and `triggers == 0`.
+- Claude.ai has no subagents, so run test cases yourself, skip baselines, and
+  focus on qualitative review.
+- Cowork has subagents but may lack a browser; generate a static viewer with
+  `eval-viewer/generate_review.py --static <output_path>`.
+- Description optimization requires `claude -p` or `codex exec`; skip it when no
+  suitable CLI is available.
 
-### How skill triggering works
+## Package and present
 
-Understanding the triggering mechanism helps design better eval queries.
-
-**Claude Code:** Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description.
-
-**Codex CLI:** Repository skills are discovered from `.agents/skills/` directories from the current working directory up to the repository root. User skills live under `$HOME/.agents/skills`, admin skills under `/etc/codex/skills`, and system skills are bundled with Codex. Codex reads the SKILL.md frontmatter (`name` and `description`) to decide when to use a skill. The triggering mechanism is semantically similar to Claude Code's.
-
-In both cases, the agent only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because the agent can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
-
-This means your eval queries should be substantive enough that the agent would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
-
-### Step 4: Apply the result
-
-Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
-
----
-
-### Package and Present (only if `present_files` tool is available)
-
-Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+If a file presentation tool is available, package the final skill:
 
 ```bash
-cd <skill-forge-path>
 uv run python -m scripts.package_skill <path/to/skill-folder>
 ```
 
-After packaging, direct the user to the resulting `.skill` file path so they can install it.
+Otherwise, return the generated `.skill` path to the user.
 
----
+## Final checklist
 
-## Claude.ai-specific instructions
-
-In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
-
-**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
-
-**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
-
-**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
-
-**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
-
-**Description optimization**: This section requires either the `claude` CLI tool (`claude -p`) or `codex` CLI tool (`codex exec`). Use `--cli codex` when running with Codex. Skip it if you're on Claude.ai.
-
-**Blind comparison**: Requires subagents. Skip it.
-
-**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
-
----
-
-## Cowork-Specific Instructions
-
-If you're in Cowork, the main things to know are:
-
-- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
-- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
-- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
-- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
-- Packaging works — `package_skill.py` just needs Python and a filesystem.
-- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
-
----
-
-## Reference files
-
-The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
-
-- `agents/grader.md` — How to evaluate expectations against outputs
-- `agents/comparator.md` — How to do blind A/B comparison between two outputs
-- `agents/analyzer.md` — How to analyze why one version beat another
-
-The references/ directory has additional documentation:
-- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
-
----
-
-Repeating one more time the core loop here for emphasis:
-
-- Figure out what the skill is about
-- Draft or edit the skill
-- Run claude-with-access-to-the-skill on test prompts
-- With the user, evaluate the outputs:
-  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
-  - Run quantitative evals
-- Repeat until you and the user are satisfied
-- Package the final skill and return it to the user.
-
-Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
-
-Good luck!
+- Skill boundary is clear in frontmatter `description`.
+- `SKILL.md` stays lean and points to references for branch-specific detail.
+- Claude and Codex validation paths are explicit.
+- Codex metadata is regenerated after `SKILL.md` changes.
+- Evals, expectations, grading, benchmark, and viewer artifacts use the schemas
+  in `references/schemas.md`.
+- User feedback is incorporated before packaging.

--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -50,7 +50,7 @@ The skill creator is liable to be used by people across a wide range of familiar
 So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
 
 - "evaluation" and "benchmark" are borderline, but OK
-- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+- for "JSON" and "expectation" you want to see serious cues from the user that they know what those things are before using them without explaining them
 
 It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
 
@@ -158,7 +158,7 @@ Try to explain to the model why things are important in lieu of heavy-handed mus
 
 After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
 
-Save test cases to `evals/evals.json` inside the skill directory (e.g., `<skill-dir>/evals/evals.json`). This keeps eval definitions co-located with the skill they test. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+Save test cases to `evals/evals.json` inside the skill directory (e.g., `<skill-dir>/evals/evals.json`). This keeps eval definitions co-located with the skill they test. Don't write expectations yet — just the prompts. You'll draft expectations in the next step while the runs are in progress.
 
 ```json
 {
@@ -174,7 +174,7 @@ Save test cases to `evals/evals.json` inside the skill directory (e.g., `<skill-
 }
 ```
 
-See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+See `references/schemas.md` for the full schema, including the `expectations` field you'll add later.
 
 ## Python environment setup
 
@@ -250,24 +250,24 @@ Execute this task:
 - **Creating a new skill**: no skill at all. Same prompt, no skill path, working directory `<workspace>/iteration-<N>/eval-<ID>/without_skill/`, save outputs to `without_skill/outputs/`.
 - **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Working directory `<workspace>/iteration-<N>/eval-<ID>/old_skill/`, save outputs to `old_skill/outputs/`.
 
-Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+Write an `eval_metadata.json` for each test case (`expectations` can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
 
 ```json
 {
   "eval_id": 0,
   "eval_name": "descriptive-name-here",
   "prompt": "The user's task prompt",
-  "assertions": []
+  "expectations": []
 }
 ```
 
-### Step 2: While runs are in progress, draft assertions
+### Step 2: While runs are in progress, draft expectations
 
-Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative expectations for each test case and explain them to the user. If expectations already exist in `evals/evals.json`, review them and explain what they check.
 
-Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+Good expectations are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force expectations onto things that need human judgment.
 
-Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+Update the `eval_metadata.json` files and `evals/evals.json` with the expectations once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
 
 ### Step 3: As runs complete, capture timing data
 
@@ -287,7 +287,7 @@ This is the only opportunity to capture this data — it comes through the task 
 
 Once all runs are done:
 
-1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each expectation against the outputs. Save results to `grading.json` in each run directory. The `grading.json` expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For expectations that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
 
 2. **Aggregate into benchmark** — run the aggregation script from the skill-forge directory:
    ```bash
@@ -310,7 +310,7 @@ Put each with_skill version before its baseline counterpart.
 
    Extract the values from `benchmark.json`. This gives the skill a persistent quality record that travels with the source code.
 
-4. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+4. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like expectations that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
 
 5. **Launch the viewer** with both qualitative outputs and quantitative data:
    ```bash
@@ -335,7 +335,7 @@ The "Outputs" tab shows one test case at a time:
 - **Prompt**: the task that was given
 - **Output**: the files the skill produced, rendered inline where possible
 - **Previous Output** (iteration 2+): collapsed section showing last iteration's output
-- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Formal Grades** (if grading was run): collapsed section showing expectation pass/fail
 - **Feedback**: a textbox that auto-saves as they type
 - **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
 
@@ -568,7 +568,7 @@ If you're in Cowork, the main things to know are:
 
 The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
 
-- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/grader.md` — How to evaluate expectations against outputs
 - `agents/comparator.md` — How to do blind A/B comparison between two outputs
 - `agents/analyzer.md` — How to analyze why one version beat another
 

--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Create or improve Claude Code and Codex skills. Use only when the request is
   explicitly about the skill itself: creating a new skill, editing a SKILL.md
   file, testing a skill draft in .claude/skills/.../SKILL.md or
-  .codex/skills/.../SKILL.md, improving an existing skill, debugging why a
+  .agents/skills/.../SKILL.md, improving an existing skill, debugging why a
   skill is not triggering, running evals or benchmarks for a skill, or turning
   an already-described workflow into a reusable skill. Trigger on phrases like
   existing skill, skill draft, SKILL.md, skill trigger, skill eval, make this
@@ -201,7 +201,7 @@ WORKSPACE=$(mktemp -d)
 echo "Workspace: $WORKSPACE"
 ```
 
-This ensures a clean, isolated environment for each evaluation run. If you need persistence across sessions (e.g., to resume an interrupted run), you can instead use a fixed path: `.claude/skills-workspaces/<skill-name>/` for Claude Code, or `.codex/skills-workspaces/<skill-name>/` for Codex CLI. After creating the workspace, run `ls $WORKSPACE` to verify it exists. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+This ensures a clean, isolated environment for each evaluation run. If you need persistence across sessions (e.g., to resume an interrupted run), you can instead use a fixed path: `.claude/skills-workspaces/<skill-name>/` for Claude Code, or `.codex/skills-workspaces/<skill-name>/` for Codex CLI. These workspace paths are only for eval outputs; Codex skill discovery uses `.agents/skills`, not `.codex/skills`. After creating the workspace, run `ls $WORKSPACE` to verify it exists. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
 
 **Important: Always display the workspace path to the user** so they can inspect outputs directly. When eval runs complete, also display the full path to each generated output file.
 
@@ -274,7 +274,7 @@ Once all runs are done:
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
 Put each with_skill version before its baseline counterpart.
 
-3. **Save benchmark results to the skill folder** — After aggregation, copy the benchmark to the skill's own directory so results are tracked alongside the skill source. `<skill-dir>` is the actual skill source directory (not a symlink or cache path). Note that `<workspace>` varies by CLI: `.claude/skills-workspaces/<skill-name>/` for Claude Code (or `$CLAUDE_CONFIG_DIR/skills-workspaces/<skill-name>/` if set), `.codex/skills-workspaces/<skill-name>/` for Codex CLI (or `$CODEX_HOME/skills-workspaces/<skill-name>/` if set). Use the same workspace path that was resolved in the "Running and evaluating test cases" section above.
+3. **Save benchmark results to the skill folder** — After aggregation, copy the benchmark to the skill's own directory so results are tracked alongside the skill source. `<skill-dir>` is the actual skill source directory (not a symlink or cache path). Note that `<workspace>` varies by CLI: `.claude/skills-workspaces/<skill-name>/` for Claude Code (or `$CLAUDE_CONFIG_DIR/skills-workspaces/<skill-name>/` if set), `.codex/skills-workspaces/<skill-name>/` for Codex CLI (or `$CODEX_HOME/skills-workspaces/<skill-name>/` if set). These are eval result workspaces, not skill discovery directories. Use the same workspace path that was resolved in the "Running and evaluating test cases" section above.
    ```bash
    mkdir -p <skill-dir>/evals/benchmarks
    cp <workspace>/iteration-<N>/benchmark.json \
@@ -479,7 +479,7 @@ Understanding the triggering mechanism helps design better eval queries.
 
 **Claude Code:** Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description.
 
-**Codex CLI:** Skills are discovered from `.codex/skills/` (and `.agents/skills/`). Codex reads the SKILL.md frontmatter (`name` and `description`) to decide when to use a skill. The triggering mechanism is semantically similar to Claude Code's.
+**Codex CLI:** Repository skills are discovered from `.agents/skills/` directories from the current working directory up to the repository root. User skills live under `$HOME/.agents/skills`, admin skills under `/etc/codex/skills`, and system skills are bundled with Codex. Codex reads the SKILL.md frontmatter (`name` and `description`) to decide when to use a skill. The triggering mechanism is semantically similar to Claude Code's.
 
 In both cases, the agent only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because the agent can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
 

--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -190,6 +190,18 @@ After this, use `uv run` for every script call (shown in the examples below). `u
 
 If `uv` is not installed, direct the user to https://docs.astral.sh/uv/ — it's a one-line install and there's no alternative setup path.
 
+## Validating skills
+
+Use `scripts/quick_validate.py` before packaging or publishing a skill. The validator supports platform-specific checks:
+
+```bash
+uv run python scripts/quick_validate.py <skill-dir>                  # auto: accepts Claude/Codex frontmatter and validates agents/openai.yaml if present
+uv run python scripts/quick_validate.py <skill-dir> --platform claude
+uv run python scripts/quick_validate.py <skill-dir> --platform codex
+```
+
+Use `--platform claude` when checking Claude Code-only frontmatter such as `disable-model-invocation`, `user-invocable`, or `when_to_use`. Use `--platform codex` when checking Codex skills and `agents/openai.yaml` metadata.
+
 ## Running and evaluating test cases
 
 This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.

--- a/plugins/agent-skills/skills/skill-forge/agents/analyzer.md
+++ b/plugins/agent-skills/skills/skill-forge/agents/analyzer.md
@@ -208,7 +208,7 @@ You receive these parameters in your prompt:
 2. Note the configurations tested (with_skill, without_skill)
 3. Understand the run_summary aggregates already calculated
 
-### Step 2: Analyze Per-Assertion Patterns
+### Step 2: Analyze Per-Expectation Patterns
 
 For each expectation across all runs:
 - Does it **always pass** in both configurations? (may not differentiate skill value)
@@ -239,7 +239,7 @@ Write freeform observations as a list of strings. Each note should:
 - Help the user understand something the aggregate metrics don't show
 
 Examples:
-- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Expectation 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
 - "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
 - "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
 - "Skill adds 13s average execution time but improves pass rate by 50%"
@@ -252,7 +252,7 @@ Save notes to `{output_path}` as a JSON array of strings:
 
 ```json
 [
-  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Expectation 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
   "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
   "Without-skill runs consistently fail on table extraction expectations",
   "Skill adds 13s average execution time but improves pass rate by 50%"

--- a/plugins/agent-skills/skills/skill-forge/agents/comparator.md
+++ b/plugins/agent-skills/skills/skill-forge/agents/comparator.md
@@ -65,7 +65,7 @@ For each output (A and B):
 2. **Calculate dimension totals**: Content score, Structure score
 3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
 
-### Step 5: Check Assertions (if provided)
+### Step 5: Check Expectations (if provided)
 
 If expectations are provided:
 
@@ -79,7 +79,7 @@ If expectations are provided:
 Compare A and B based on (in priority order):
 
 1. **Primary**: Overall rubric score (content + structure)
-2. **Secondary**: Assertion pass rates (if applicable)
+2. **Secondary**: Expectation pass rates (if applicable)
 3. **Tiebreaker**: If truly equal, declare a TIE
 
 Be decisive - ties should be rare. One output is usually better, even if marginally.
@@ -196,7 +196,7 @@ If no expectations were provided, omit the `expectation_results` field entirely.
 - **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
 - **Be specific**: Cite specific examples when explaining strengths and weaknesses.
 - **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
-- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Output quality first**: Expectation scores are secondary to overall task completion.
 - **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
 - **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
 - **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/plugins/agent-skills/skills/skill-forge/agents/grader.md
+++ b/plugins/agent-skills/skills/skill-forge/agents/grader.md
@@ -6,7 +6,7 @@ Evaluate expectations against an execution transcript and outputs.
 
 The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
 
-You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak expectation is worse than useless — it creates false confidence. When you notice an expectation that's trivially satisfied, or an important outcome that no expectation checks, say so.
 
 ## Inputs
 
@@ -30,7 +30,7 @@ You receive these parameters in your prompt:
 2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
 3. Note contents, structure, and quality
 
-### Step 3: Evaluate Each Assertion
+### Step 3: Evaluate Each Expectation
 
 For each expectation:
 
@@ -69,14 +69,14 @@ If `{outputs_dir}/user_notes.md` exists:
 
 After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
 
-Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+Good suggestions test meaningful outcomes — expectations that are hard to satisfy without actually doing the work correctly. Think about what makes an expectation *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
 
 Suggestions worth raising:
-- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
-- An important outcome you observed — good or bad — that no assertion covers at all
-- An assertion that can't actually be verified from the available outputs
+- An expectation that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no expectation covers at all
+- An expectation that can't actually be verified from the available outputs
 
-Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every expectation.
 
 ### Step 7: Write Grading Results
 
@@ -93,8 +93,8 @@ Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
 - No evidence found for the expectation
 - Evidence contradicts the expectation
 - The expectation cannot be verified from available information
-- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
-- The output appears to meet the assertion by coincidence rather than by actually doing the work
+- The evidence is superficial — the expectation is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the expectation by coincidence rather than by actually doing the work
 
 **When uncertain**: The burden of proof to pass is on the expectation.
 
@@ -171,14 +171,14 @@ Write a JSON file with this structure:
   "eval_feedback": {
     "suggestions": [
       {
-        "assertion": "The output includes the name 'John Smith'",
+        "expectation": "The output includes the name 'John Smith'",
         "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
       },
       {
-        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+        "reason": "No expectation checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
       }
     ],
-    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+    "overall": "Expectations check presence but not correctness. Consider adding content verification."
   }
 }
 ```
@@ -210,7 +210,7 @@ Write a JSON file with this structure:
   - **needs_review**: Items requiring human attention
   - **workarounds**: Places where the skill didn't work as expected
 - **eval_feedback**: Improvement suggestions for the evals (only when warranted)
-  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `expectation` it relates to
   - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
 
 ## Guidelines

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: a2836f6e78fbd2a451271fb736f2345d87fd0d230cdab6cddd1c7f004302fedc
+# skill-forge-source-sha256: ee65fb828a33eb96c83f4149314e7bf353bb43bd88fa951cce834fe6792032e8
 interface:
   display_name: "Skill Forge"
   short_description: "Create and improve agent skills"

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,0 +1,5 @@
+# skill-forge-source-sha256: bfa86107e99501d9f168b4cbdaec98d5cc14b02ed215af5750fd4b1dfea37100
+interface:
+  display_name: "Skill Forge"
+  short_description: "Create and improve agent skills"
+  default_prompt: "Use $skill-forge to improve this skill."

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: ee65fb828a33eb96c83f4149314e7bf353bb43bd88fa951cce834fe6792032e8
+# skill-forge-source-sha256: bc802a584480e61eb66a7b01373efb49340c8bcea9bf2fca37f5b5d560f053ba
 interface:
   display_name: "Skill Forge"
   short_description: "Create and improve agent skills"

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: bc802a584480e61eb66a7b01373efb49340c8bcea9bf2fca37f5b5d560f053ba
+# skill-forge-source-sha256: afb86a5c30ad7a3be02f4d2d488bd44194bd06a7023fee83b7303b3fec9640bb
 interface:
   display_name: "Skill Forge"
   short_description: "Create and improve agent skills"

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: bfa86107e99501d9f168b4cbdaec98d5cc14b02ed215af5750fd4b1dfea37100
+# skill-forge-source-sha256: a2836f6e78fbd2a451271fb736f2345d87fd0d230cdab6cddd1c7f004302fedc
 interface:
   display_name: "Skill Forge"
   short_description: "Create and improve agent skills"

--- a/plugins/agent-skills/skills/skill-forge/eval-viewer/generate_review.py
+++ b/plugins/agent-skills/skills/skill-forge/eval-viewer/generate_review.py
@@ -135,6 +135,8 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
             except (json.JSONDecodeError, OSError):
                 pass
             if grading:
+                if "expectations" not in grading and "assertions" in grading:
+                    grading["expectations"] = grading["assertions"]
                 break
 
     return {

--- a/plugins/agent-skills/skills/skill-forge/eval-viewer/viewer.html
+++ b/plugins/agent-skills/skills/skill-forge/eval-viewer/viewer.html
@@ -885,7 +885,7 @@
       html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
       html += '</div>';
 
-      // Assertions list
+      // Expectations list
       html += '<ul class="assertion-list">';
       for (const exp of expectations) {
         const statusClass = exp.passed ? "pass" : "fail";
@@ -1250,42 +1250,42 @@
           }
           html += "</tbody></table>";
 
-          // Per-assertion detail for this eval
+          // Per-expectation detail for this eval
           const runsWithExpectations = {};
           for (const config of configGroups) {
             runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
           }
           const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
           if (hasAnyExpectations) {
-            // Collect all unique assertion texts across all configs
-            const allAssertions = [];
+            // Collect all unique expectation texts across all configs
+            const allExpectations = [];
             const seen = new Set();
             for (const config of configGroups) {
               for (const run of runsWithExpectations[config]) {
                 for (const exp of (run.expectations || [])) {
                   if (!seen.has(exp.text)) {
                     seen.add(exp.text);
-                    allAssertions.push(exp.text);
+                    allExpectations.push(exp.text);
                   }
                 }
               }
             }
 
             html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
-            html += "<thead><tr><th>Assertion</th>";
+            html += "<thead><tr><th>Expectation</th>";
             for (const config of configGroups) {
               const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
               html += "<th>" + escapeHtml(label) + "</th>";
             }
             html += "</tr></thead><tbody>";
 
-            for (const assertionText of allAssertions) {
-              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+            for (const expectationText of allExpectations) {
+              html += "<tr><td>" + escapeHtml(expectationText) + "</td>";
 
               for (const config of configGroups) {
                 html += "<td>";
                 for (const run of runsWithExpectations[config]) {
-                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  const exp = (run.expectations || []).find(e => e.text === expectationText);
                   if (exp) {
                     const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
                     const icon = exp.passed ? "\u2713" : "\u2717";

--- a/plugins/agent-skills/skills/skill-forge/references/description_optimization.md
+++ b/plugins/agent-skills/skills/skill-forge/references/description_optimization.md
@@ -1,0 +1,140 @@
+# Description optimization
+
+Read this reference after creating or improving a skill when the user wants
+better trigger accuracy, or when debugging why a skill triggers too often or not
+often enough.
+
+## Purpose
+
+The `description` field in `SKILL.md` frontmatter is the primary trigger signal.
+After the skill body is stable, offer to optimize the description.
+
+## Generate trigger eval queries
+
+Before drafting queries, read the target skill's `SKILL.md` and extract two
+short lists:
+
+- `helps with`: user intents and situations the skill is meant to handle.
+- `should not help with`: adjacent requests or keywords that look similar but
+  belong to a different skill or normal workflow.
+
+Use those lists to anchor the eval set to the skill's real boundary.
+
+Create 20 realistic eval queries as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+Use a mix of long and short prompts, formal and casual phrasing, typos, file
+paths, personal context, and near misses.
+
+Good should-trigger cases cover different ways of asking for the same underlying
+workflow. Good should-not-trigger cases are adjacent and tricky, not obviously
+irrelevant.
+
+Bad:
+
+```text
+"Format this data"
+"Extract text from PDF"
+"Create a chart"
+```
+
+Good:
+
+```text
+"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"
+```
+
+## Review with the user
+
+Use `assets/eval_review.html`:
+
+1. Read the template.
+2. Replace `__EVAL_DATA_PLACEHOLDER__` with the JSON array, without quotes.
+3. Replace `__SKILL_NAME_PLACEHOLDER__` with the skill name.
+4. Replace `__SKILL_DESCRIPTION_PLACEHOLDER__` with the current description.
+5. Write to a temp file such as `/tmp/eval_review_<skill-name>.html`.
+6. Open it with `open /tmp/eval_review_<skill-name>.html`.
+7. After the user exports, read the newest `~/Downloads/eval_set*.json`.
+
+This review matters because bad eval queries produce bad descriptions.
+
+## Run the optimization loop
+
+Tell the user the loop will take time and that you will check on it
+periodically.
+
+Before changing trigger eval parsing or interpreting surprising results, read
+`references/trigger_eval_boundaries.md`. It documents Claude Code and Codex CLI
+detector signals, false positives, false negatives, and the difference between a
+successful non-trigger and zero successful runs.
+
+Claude Code:
+
+```bash
+uv run python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Codex CLI:
+
+```bash
+uv run python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --cli codex \
+  --max-iterations 5 \
+  --verbose
+```
+
+The `--cli` flag selects `claude` or `codex`. If omitted, the script auto-detects
+from PATH. `SKILL_FORGE_EVAL_CLI` can also select the CLI.
+
+Use the model ID from the current session so the eval matches the user's actual
+experience. The same CLI selection is used for evaluation and description
+improvement. No separate Anthropic API client setup is required for the
+optimization loop.
+
+While it runs, tail output and report iteration scores.
+
+The loop splits evals into 60% train and 40% held-out test, evaluates each query
+three times, proposes improvements, and selects `best_description` by held-out
+test score to reduce overfitting.
+
+If a query result has `status: "error"` or `status: "not_run"`, treat it as eval
+infrastructure failure. A successful non-trigger has `status: "ok"`, `runs > 0`,
+and `triggers == 0`.
+
+## How skill triggering works
+
+Claude Code skills appear in Claude's `available_skills` list with name and
+description. Claude decides whether to consult a skill from that metadata.
+
+Codex CLI discovers repository skills from `.agents/skills/` directories from
+the current working directory up to the repository root. User skills live under
+`$HOME/.agents/skills`, admin skills under `/etc/codex/skills`, and system
+skills are bundled with Codex. Codex reads `SKILL.md` frontmatter `name` and
+`description` to decide when to use a skill.
+
+In both platforms, simple one-step tasks may not trigger a skill even if the
+description matches because the agent can handle them directly. Trigger eval
+queries should be substantive enough that the agent benefits from consulting the
+skill.
+
+## Apply the result
+
+Take `best_description` from the JSON output and update the target skill's
+`SKILL.md` frontmatter. Show the user before/after and report the scores.
+
+If changing this skill-forge skill itself, regenerate `agents/openai.yaml` after
+the `SKILL.md` edit.

--- a/plugins/agent-skills/skills/skill-forge/references/eval_workflow.md
+++ b/plugins/agent-skills/skills/skill-forge/references/eval_workflow.md
@@ -1,0 +1,230 @@
+# Eval workflow
+
+Read this reference when creating or running skill evals, comparing a new skill
+against a baseline, grading outputs, launching the review viewer, or iterating on
+feedback.
+
+## Overview
+
+The eval loop is one continuous sequence:
+
+1. Create an isolated workspace.
+2. Spawn each eval with the skill and with the appropriate baseline in the same
+   turn.
+3. Draft expectations while runs are in progress.
+4. Capture timing data as run notifications arrive.
+5. Grade, aggregate, analyze, and launch the viewer.
+6. Read user feedback and iterate.
+
+Do not use `/skill-test` or another testing skill for this workflow.
+
+## Workspace
+
+Create an isolated workspace before any eval runs:
+
+```bash
+WORKSPACE=$(mktemp -d)
+echo "Workspace: $WORKSPACE"
+ls "$WORKSPACE"
+```
+
+Always display the workspace path to the user. If persistence is needed, use a
+fixed eval-output path such as `.claude/skills-workspaces/<skill-name>/` for
+Claude Code or `.codex/skills-workspaces/<skill-name>/` for Codex CLI. These are
+only output workspaces; Codex skill discovery uses `.agents/skills`, not
+`.codex/skills`.
+
+Organize outputs by iteration and eval:
+
+```text
+iteration-1/
+  eval-0-name/
+    with_skill/
+    without_skill/    # for a new skill baseline
+    old_skill/        # for an existing skill baseline
+```
+
+## Spawn eval runs
+
+For each test case, spawn both the with-skill run and baseline run in the same
+turn so they complete on roughly the same schedule.
+
+Each run must use an isolated working directory under the workspace, not the
+skill source directory.
+
+With-skill run:
+
+```text
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Working directory: <workspace>/iteration-<N>/<eval-name>/with_skill/
+- Save outputs to: <workspace>/iteration-<N>/<eval-name>/with_skill/outputs/
+- Outputs to save: <what the user cares about>
+```
+
+Baseline choices:
+
+- New skill: use no skill. Save outputs under `without_skill/`.
+- Existing skill: snapshot the old version before editing, then use the snapshot
+  as the baseline. Save outputs under `old_skill/`.
+
+Write an `eval_metadata.json` for each eval directory:
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "expectations": []
+}
+```
+
+## Draft expectations
+
+While eval runs are in progress, draft quantitative expectations and explain
+them to the user. If `evals/evals.json` already contains expectations, review
+them and explain what they check.
+
+Good expectations are objective and descriptive. Subjective skills are better
+evaluated qualitatively; do not force weak metrics onto work that needs human
+judgment.
+
+Update `eval_metadata.json` and `evals/evals.json` once expectations are drafted.
+Writers must emit `expectations`; old hand-written `assertions` may be accepted
+only as a legacy alias by readers.
+
+## Capture timing
+
+When each subagent task completes, save the notification's `total_tokens` and
+`duration_ms` immediately to `timing.json` in that run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This data is not persisted elsewhere.
+
+## Grade and aggregate
+
+Grade each run by reading `agents/grader.md` and evaluating each expectation
+against the outputs. Save `grading.json` in each run directory. The expectations
+array must use `text`, `passed`, and `evidence`.
+
+For programmatically checkable expectations, write and run a script instead of
+eyeballing the output.
+
+Aggregate from the skill-forge directory:
+
+```bash
+uv run python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+```
+
+This produces `benchmark.json` and `benchmark.md`. If writing benchmark JSON
+manually, use `references/schemas.md`.
+
+Put each with-skill version before its baseline counterpart.
+
+## Persist benchmark history
+
+Copy the benchmark back to the skill folder:
+
+```bash
+mkdir -p <skill-dir>/evals/benchmarks
+cp <workspace>/iteration-<N>/benchmark.json \
+  <skill-dir>/evals/benchmarks/$(date +%Y-%m-%d)-iteration-<N>.json
+```
+
+Create or update `<skill-dir>/evals/benchmarks/README.md` with:
+
+```markdown
+| Iteration | Date | Pass Rate (with skill) | Pass Rate (baseline) | Avg Tokens | Avg Duration |
+|-----------|------|------------------------|----------------------|------------|--------------|
+```
+
+## Analyze benchmark results
+
+Read `agents/analyzer.md` and look for patterns aggregate stats can hide:
+
+- Expectations that always pass regardless of skill.
+- Evals with high variance or flaky results.
+- Token/time tradeoffs.
+- Cases where the baseline beats the skill.
+
+## Launch the review viewer
+
+Use the bundled viewer, not custom HTML:
+
+```bash
+nohup uv run --project <skill-forge-path> python <skill-forge-path>/eval-viewer/generate_review.py \
+  <workspace>/iteration-N \
+  --skill-name "my-skill" \
+  --benchmark <workspace>/iteration-N/benchmark.json \
+  > /dev/null 2>&1 &
+VIEWER_PID=$!
+```
+
+For iteration 2+, add:
+
+```bash
+--previous-workspace <workspace>/iteration-<N-1>
+```
+
+Headless environments should use:
+
+```bash
+--static <output_path>
+```
+
+Tell the user the viewer has two tabs: **Outputs** for qualitative review and
+**Benchmark** for quantitative comparison.
+
+## Read feedback
+
+When the user is done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the output looked fine. Focus improvements on cases with
+specific complaints.
+
+Kill the viewer server when finished:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+## Improve and iterate
+
+After feedback:
+
+1. Apply improvements to the skill.
+2. Rerun all test cases into `iteration-<N+1>/`, including baselines.
+3. Launch the viewer with `--previous-workspace`.
+4. Wait for user review.
+5. Read feedback and repeat.
+
+Stop when the user is happy, feedback is empty, or changes are no longer making
+meaningful progress.
+
+When revising, generalize from feedback instead of overfitting to one eval. Read
+transcripts, remove instructions that cause wasted work, and bundle helper
+scripts when repeated work appears across evals.
+
+## Blind comparison
+
+For rigorous A/B comparison between two skill versions, read
+`agents/comparator.md` and `agents/analyzer.md`. This requires subagents and is
+optional for most workflows.

--- a/plugins/agent-skills/skills/skill-forge/references/openai_yaml.md
+++ b/plugins/agent-skills/skills/skill-forge/references/openai_yaml.md
@@ -1,0 +1,109 @@
+# Codex agents/openai.yaml metadata
+
+Use this reference when creating or improving a Codex-compatible skill.
+
+## Purpose
+
+`agents/openai.yaml` is optional Codex metadata for UI presentation, invocation policy, and tool dependency declarations. Codex still uses `SKILL.md` frontmatter `name` and `description` for skill discovery and triggering.
+
+Add `agents/openai.yaml` when a skill is intended for Codex users, plugins, or marketplace-style distribution.
+
+## Generate metadata
+
+Run this from the `skill-forge` skill directory:
+
+```bash
+uv run python scripts/generate_openai_yaml.py <skill-dir>
+```
+
+Override interface fields when the generated defaults are too generic:
+
+```bash
+uv run python scripts/generate_openai_yaml.py <skill-dir> \
+  --interface display_name="PDF Toolkit" \
+  --interface short_description="Create and verify PDF files" \
+  --interface default_prompt="Use $pdf-toolkit to inspect this PDF."
+```
+
+After changing `SKILL.md`, regenerate `agents/openai.yaml`.
+
+## Validate metadata
+
+Use strict validation before publishing a Codex skill:
+
+```bash
+uv run python scripts/quick_validate.py <skill-dir> --platform codex --strict-openai-yaml
+```
+
+Strict validation checks that:
+
+- `agents/openai.yaml` exists.
+- `agents/openai.yaml` contains the generated `SKILL.md` source hash.
+- The generated source hash still matches the current `SKILL.md`.
+- `interface.display_name`, `interface.short_description`, and `interface.default_prompt` are present and non-empty.
+- `interface.short_description` is 25-64 characters.
+- `interface.default_prompt` explicitly mentions the skill as `$skill-name`.
+- Optional `policy.allow_implicit_invocation` is a boolean.
+- Optional `dependencies.tools[]` entries use supported string fields.
+
+Non-strict validation remains compatible with existing OpenAI bundled skills that omit some strict authoring constraints.
+
+## Field constraints
+
+### `interface.display_name`
+
+Human-facing title shown in Codex skill lists and chips.
+
+Use title case or the product's official capitalization. Keep it concise enough for UI labels.
+
+### `interface.short_description`
+
+Human-facing UI blurb for quick scanning.
+
+Use 25-64 characters. State the job, not trigger logic. Examples:
+
+- `Create and verify PDF files`
+- `Draft and refine GitHub PRs`
+- `Build spreadsheet workflows`
+
+### `interface.default_prompt`
+
+Prompt snippet inserted when invoking the skill.
+
+Use one short sentence. Mention the skill explicitly as `$skill-name`, for example:
+
+```yaml
+default_prompt: "Use $pdf-toolkit to inspect this PDF."
+```
+
+### `policy.allow_implicit_invocation`
+
+When `false`, Codex does not implicitly invoke the skill from a matching prompt. Explicit `$skill-name` invocation still works. Defaults to `true` when omitted.
+
+### `dependencies.tools[]`
+
+Declare external tool dependencies for UI and setup clarity.
+
+Supported fields:
+
+- `type`
+- `value`
+- `description`
+- `transport`
+- `url`
+
+Only `type: "mcp"` is supported for now.
+
+## Difference from OpenAI skill-creator
+
+OpenAI's built-in `skill-creator`:
+
+- Recommends `agents/openai.yaml` for UI metadata.
+- Provides `references/openai_yaml.md`.
+- Provides `scripts/generate_openai_yaml.py`.
+- Treats `display_name`, `short_description`, and `default_prompt` as generated human-facing interface values.
+
+skill-forge follows that shape, with two deliberate differences:
+
+- `quick_validate.py` has a compatibility mode by default and a stricter `--strict-openai-yaml` mode for publishing.
+- Strict validation detects stale metadata by comparing a generated `SKILL.md` source hash in `agents/openai.yaml`, so authors can catch forgotten regeneration after editing `SKILL.md` without relying on filesystem timestamps.

--- a/plugins/agent-skills/skills/skill-forge/references/platform_notes.md
+++ b/plugins/agent-skills/skills/skill-forge/references/platform_notes.md
@@ -1,0 +1,39 @@
+# Platform notes
+
+Read this reference when adapting skill-forge workflows to Claude.ai, Cowork, or
+another environment where subagents, browsers, or local CLI behavior differ.
+
+## Claude.ai
+
+The core workflow is still draft, test, review, improve, and repeat. Because
+Claude.ai does not have subagents, some mechanics change:
+
+- Run test cases one at a time yourself after reading the skill's `SKILL.md`.
+- Skip baseline runs.
+- Skip quantitative benchmarking because baseline comparisons are not meaningful
+  without independent runs.
+- If a browser is unavailable, present results directly in the conversation.
+- Save generated files to the filesystem and tell the user where they are.
+- Ask for qualitative feedback inline.
+- Description optimization requires `claude -p` or `codex exec`; use
+  `--cli codex` when running with Codex. Skip it if no CLI is available.
+- Blind comparison requires subagents, so skip it.
+- `package_skill.py` still works anywhere with Python and a filesystem.
+
+## Cowork
+
+Cowork has subagents, so the main eval workflow works. If timeouts are severe,
+running prompts in series is acceptable.
+
+Cowork may not have a browser or display. Generate the eval viewer with
+`--static <output_path>` so the user can open a standalone HTML file.
+
+Always generate the eval viewer with `eval-viewer/generate_review.py` before
+evaluating inputs yourself. Get the examples in front of the human quickly.
+
+Feedback works differently in static mode: the viewer downloads `feedback.json`
+when the user clicks "Submit All Reviews". Read that downloaded file before the
+next iteration.
+
+Packaging works normally. Description optimization should work because
+`run_loop.py` and `run_eval.py` use CLI subprocesses rather than a browser.

--- a/plugins/agent-skills/skills/skill-forge/references/schemas.md
+++ b/plugins/agent-skills/skills/skill-forge/references/schemas.md
@@ -8,6 +8,8 @@ This document defines the JSON schemas used by skill-forge.
 
 Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
 
+Canonical graded checks are called `expectations`. Older hand-written files may use `assertions`; readers should normalize that legacy field to `expectations` when accepting old artifacts, and writers must emit `expectations`.
+
 ```json
 {
   "skill_name": "example-skill",
@@ -33,6 +35,32 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
 - `evals[].expected_output`: Human-readable description of success
 - `evals[].files`: Optional list of input file paths (relative to skill root)
 - `evals[].expectations`: List of verifiable statements
+
+---
+
+## eval_metadata.json
+
+Per-eval metadata written next to each eval directory. Located at `<workspace>/iteration-<N>/eval-<ID>/eval_metadata.json`.
+
+Use `expectations` as the canonical field for verifiable checks. Older hand-written files may use `assertions`; readers may accept that field as a legacy alias, but writers must emit `expectations`.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "invoice-table-extraction",
+  "prompt": "The user's task prompt",
+  "expectations": [
+    "The output includes a table with invoice number, date, and total",
+    "The extracted total matches the source invoice"
+  ]
+}
+```
+
+**Fields:**
+- `eval_id`: Numeric eval identifier
+- `eval_name`: Human-readable eval name used by the viewer
+- `prompt`: User prompt under test
+- `expectations`: List of verifiable statements for grading
 
 ---
 
@@ -173,11 +201,11 @@ Output from the grader agent. Located at `<run-dir>/grading.json`.
   "eval_feedback": {
     "suggestions": [
       {
-        "assertion": "The output includes the name 'John Smith'",
+        "expectation": "The output includes the name 'John Smith'",
         "reason": "A hallucinated document that mentions the name would also pass"
       }
     ],
-    "overall": "Assertions check presence but not correctness."
+    "overall": "Expectations check presence but not correctness."
   }
 }
 ```
@@ -189,7 +217,7 @@ Output from the grader agent. Located at `<run-dir>/grading.json`.
 - `timing`: Wall clock timing (from timing.json)
 - `claims`: Extracted and verified claims from the output
 - `user_notes_summary`: Issues flagged by the executor
-- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising. Suggestions use `expectation` for a related check; legacy `assertion` may appear only in older artifacts.
 
 ---
 
@@ -310,7 +338,7 @@ Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
   },
 
   "notes": [
-    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Expectation 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
     "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
     "Without-skill runs consistently fail on table extraction expectations",
     "Skill adds 13s average execution time but improves pass rate by 50%"

--- a/plugins/agent-skills/skills/skill-forge/references/schemas.md
+++ b/plugins/agent-skills/skills/skill-forge/references/schemas.md
@@ -36,6 +36,39 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
 
 ---
 
+## trigger eval result
+
+Output from `scripts/run_eval.py`.
+
+```json
+{
+  "query": "the user prompt",
+  "should_trigger": true,
+  "trigger_rate": 0.67,
+  "triggers": 2,
+  "runs": 3,
+  "attempted_runs": 3,
+  "status": "ok",
+  "pass": true
+}
+```
+
+**Fields:**
+- `query`: User prompt under test
+- `should_trigger`: Expected trigger decision
+- `trigger_rate`: `triggers / runs`, or `0.0` when `runs` is `0`
+- `triggers`: Successful runs where the platform detector saw a trigger signal
+- `runs`: Successful runs that returned a trigger/non-trigger result
+- `attempted_runs`: Runs requested for the query
+- `status`: `ok`, `partial_error`, `error`, or `not_run`
+- `pass`: Whether the observed trigger rate matches `should_trigger`
+- `errors`: Optional list of run error messages
+- `error_count`: Optional number of failed runs
+
+See `references/trigger_eval_boundaries.md` for platform detector limits and how to interpret `status`.
+
+---
+
 ## history.json
 
 Tracks version progression in Improve mode. Located at workspace root.

--- a/plugins/agent-skills/skills/skill-forge/references/skill_authoring.md
+++ b/plugins/agent-skills/skills/skill-forge/references/skill_authoring.md
@@ -1,0 +1,120 @@
+# Skill authoring guide
+
+Read this reference when drafting or reviewing a `SKILL.md`, especially when the
+skill body is getting long or the trigger boundary is ambiguous.
+
+## Anatomy of a skill
+
+```text
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+├── agents/
+│   └── openai.yaml - Codex UI metadata, invocation policy, and tool dependencies
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+## Progressive disclosure
+
+Skills use a three-level loading system:
+
+1. **Metadata** (`name` + `description`) - Always in context.
+2. **SKILL.md body** - Loaded whenever the skill triggers. Keep this concise;
+   under 500 lines is the target.
+3. **Bundled resources** - Loaded as needed. Scripts can execute without loading
+   all of their source into the model context.
+
+Use bundled resources when:
+
+- The `SKILL.md` body is approaching 500 lines.
+- A section is only relevant for one branch, platform, framework, or advanced
+  workflow.
+- The content is mostly reference material, examples, schemas, or long commands.
+
+Reference files must be discoverable from `SKILL.md`. Name the file and explain
+when to read it. For large reference files, include a short table of contents.
+
+When a skill supports multiple domains or frameworks, organize by variant:
+
+```text
+cloud-deploy/
+├── SKILL.md
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+
+The agent should read only the relevant reference file.
+
+## Principle of lack of surprise
+
+Skills must not contain malware, exploit code, hidden data exfiltration, or any
+instruction that would surprise the user relative to the skill's stated purpose.
+Do not create misleading skills or skills designed to facilitate unauthorized
+access. Roleplay or style skills are fine when their behavior is transparent.
+
+## Writing patterns
+
+Prefer imperative instructions. Explain why a behavior matters instead of relying
+on rigid all-caps rules.
+
+For fixed report formats, give the exact template:
+
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+For examples, make the input/output relationship explicit:
+
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+## Writing style
+
+Start with a draft, then reread it with fresh eyes. The final skill should be
+general enough to help with future tasks, not overfit to one example prompt.
+
+Use the skill body for durable workflow instructions. Put trigger criteria in
+frontmatter `description`, because the model decides whether to use a skill from
+the name and description before it reads the body.
+
+Avoid speculative flexibility. Prefer clear, concrete instructions, especially
+around tools, file locations, outputs, and verification steps.
+
+## Test cases
+
+After writing a skill draft, propose 2-3 realistic test prompts and ask the user
+whether they look right. Save test cases to `evals/evals.json` inside the skill
+directory:
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+Do not write expectations yet. Draft them while eval runs are in progress. See
+`references/schemas.md` for the full schema, including the canonical
+`expectations` field.

--- a/plugins/agent-skills/skills/skill-forge/references/skill_creator_comparison.md
+++ b/plugins/agent-skills/skills/skill-forge/references/skill_creator_comparison.md
@@ -1,0 +1,121 @@
+# Skill creator comparison
+
+Read this reference when updating skill-forge's platform assumptions, reviewing
+whether it still matches Claude Code or Codex behavior, or deciding whether a
+workflow belongs in the lean Codex creator path or the heavier eval loop.
+
+This file compares:
+
+- Anthropic's `skill-creator`
+- OpenAI's Codex `skill-creator`
+- skill-forge's deliberate extensions
+
+## Primary sources to re-check
+
+Re-check these links before making platform claims:
+
+| Source | Link | Why it matters |
+| --- | --- | --- |
+| Anthropic Claude Code skills docs | https://docs.anthropic.com/en/docs/claude-code/skills | Claude Code skill format, locations, frontmatter, packaging, and creation guidance |
+| Anthropic `skill-creator` | https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md | Upstream source for the heavy draft/eval/viewer/improve loop |
+| OpenAI Codex skills docs | https://developers.openai.com/codex/skills | Codex skill discovery, invocation, `agents/openai.yaml`, and plugin distribution guidance |
+| OpenAI `skill-creator` | https://github.com/openai/skills/blob/main/skills/.system/skill-creator/SKILL.md | Lean Codex creator workflow, `init_skill.py`, metadata generation, and validation guidance |
+| Open agent skills specification | https://agentskills.io/specification | Cross-platform skill directory and `SKILL.md` baseline vocabulary |
+
+## Creation flow comparison
+
+| Step | Claude Code / Anthropic creator | Codex / OpenAI creator | skill-forge stance |
+| --- | --- | --- | --- |
+| Intent capture | Ask what the skill should enable Claude to do, when it should trigger, output format, and whether test cases are useful. | Understand concrete examples, then plan reusable scripts, references, and assets. | Keep both: start from conversation history, then ask only for missing examples, trigger boundary, output, platform target, and eval need. |
+| Initial scaffold | Draft `SKILL.md` directly. | Run `scripts/init_skill.py <skill-name> --path <output-directory>`, optionally with resources and examples. | For Codex-first skills, prefer the OpenAI scaffold path. For existing skills or Claude-only edits, edit in place. |
+| Frontmatter | `name` and `description` are required; capture compatibility requirements when useful, then verify against current Claude docs before adding platform-specific fields. | `name` and `description` only. OpenAI's creator explicitly says not to include other YAML frontmatter fields. | Validate by platform: Claude mode accepts Claude-specific fields; Codex mode keeps `name` and `description` strict and moves UI metadata to `agents/openai.yaml`. |
+| Trigger guidance | Put all "when to use" information in `description`; body loads after trigger. | Same principle: Codex reads frontmatter `name` and `description` to decide when to use a skill. | Treat `description` as the shared trigger boundary; include true-positive triggers and near-miss exclusions there. |
+| Progressive disclosure | Keep `SKILL.md` under roughly 500 lines and move branch-specific detail to referenced resources. | Keep `SKILL.md` lean, challenge every token, move detailed material to `references/`, scripts, or assets. | Keep `SKILL.md` under 500 lines and require each reference to be linked from the body with read conditions. |
+| Bundled resources | Use `scripts/`, `references/`, and `assets/` as needed. | Same directories, plus stronger guidance to avoid auxiliary docs like README or changelog inside skills. | Use resources only when they directly support skill execution. Do not add user-facing docs unless the skill itself needs them. |
+
+## Evaluation flow comparison
+
+| Area | Claude Code / Anthropic creator | Codex / OpenAI creator | skill-forge stance |
+| --- | --- | --- | --- |
+| Built-in emphasis | Heavy eval loop: run with-skill and baseline subagents, draft checks, grade, aggregate, show viewer, iterate. | Lean loop: validate, use the skill on real tasks, notice struggles, update and test again. | Keep the heavy loop for high-risk or objectively verifiable skills; allow lean validation and real-usage iteration for small Codex skills. |
+| Baseline | New skill baseline is no skill; existing skill baseline is old snapshot. | No formal baseline in the creator workflow. | Use baselines for benchmarkable changes. Skip baselines for quick authoring or Claude.ai-style manual checks. |
+| Formal checks | Anthropic source used `assertions`; skill-forge now writes canonical `expectations`. | OpenAI creator does not prescribe a benchmark schema. | Writers emit `expectations`; readers may accept legacy `assertions` only as an alias. |
+| Viewer | Anthropic creator uses `eval-viewer/generate_review.py` for qualitative and quantitative review. | No equivalent viewer requirement in OpenAI creator. | Use the viewer when running the heavy loop. Do not force it onto simple Codex skill creation. |
+| Trigger optimization | Anthropic creator includes a description optimization loop based on trigger eval queries. | OpenAI creator emphasizes clear frontmatter and real usage iteration rather than an optimization harness. | Offer optimization after the skill body is stable; run it through Claude Code or Codex CLI according to platform. |
+
+## Distribution flow comparison
+
+| Area | Claude Code / Anthropic creator | Codex / OpenAI creator | skill-forge stance |
+| --- | --- | --- | --- |
+| Local authoring location | Claude Code uses Claude skill locations documented by Anthropic. | Codex discovers repo skills from `.agents/skills` up to repo root, user skills from `$HOME/.agents/skills`, admin skills from `/etc/codex/skills`, and bundled system skills. | Use `.agents/skills` for Codex eval/discovery paths and Claude-compatible skill folders for Claude tests. Keep eval output workspaces separate from discovery paths. |
+| Metadata | `SKILL.md` is the primary artifact. | `agents/openai.yaml` is optional but recommended for Codex UI metadata, invocation policy, and tool dependencies. | Generate and validate `agents/openai.yaml` for Codex-compatible skills; keep it out of Claude-only assumptions. |
+| Packaging | Anthropic creator packages `.skill` files when presentation/download is available. | Codex docs recommend plugins as the installable distribution unit for reusable skills and app integrations. | Package `.skill` when the user needs Claude-style export; prefer plugins for reusable Codex distribution. |
+| Validation | Anthropic creator relies on its bundled scripts and eval loop. | OpenAI creator runs `scripts/quick_validate.py`; Codex docs also emphasize trigger behavior and optional metadata. | Run `quick_validate.py` with `--platform claude` or `--platform codex`; use `--strict-openai-yaml` before publishing Codex metadata. |
+
+## OpenAI skill-creator differences
+
+OpenAI's official creator is intentionally leaner than skill-forge:
+
+- It frames skills as concise onboarding guides for Codex, not as a benchmark
+  harness.
+- It recommends creating new skills through `scripts/init_skill.py`.
+- It treats `agents/openai.yaml` as the place for UI metadata and invocation
+  policy.
+- It says `name` and `description` are the only `SKILL.md` frontmatter fields
+  Codex uses for triggering.
+- It avoids formal eval schemas, benchmark viewers, and blind comparison loops.
+- It uses real task iteration as the default improvement path.
+
+skill-forge intentionally adds:
+
+- Claude Code and Codex platform branches in one workflow.
+- Platform-aware validation modes.
+- `agents/openai.yaml` generation with stale source-hash detection.
+- Isolated eval workspaces for Claude and Codex CLI trigger tests.
+- Benchmark aggregation, viewer generation, grader/analyzer/comparator agents,
+  and trigger optimization loops.
+- Canonical `expectations` schema with legacy `assertions` read compatibility.
+
+## Anthropic-derived functionality
+
+These skill-forge capabilities come directly from or are close adaptations of
+Anthropic's `skill-creator`:
+
+- Draft, test, review, improve, repeat as the main creative loop.
+- With-skill versus baseline runs for each eval.
+- Drafting objective checks while runs are in progress.
+- Capturing timing and token data from subagent notifications.
+- Grading outputs, aggregating benchmarks, and launching the review viewer.
+- Blind comparison through comparator/analyzer agents.
+- Description trigger optimization based on realistic should-trigger and
+  should-not-trigger queries.
+- Claude.ai and Cowork environment adaptations.
+
+## skill-forge-specific extensions
+
+These are not inherited directly from either official creator and should be
+maintained as skill-forge design choices:
+
+- Cross-platform Claude Code and Codex support in one skill.
+- Codex CLI trigger evals using repo-local `.agents/skills`.
+- Claude Code trigger evals using real temporary `skills/<name>/SKILL.md`
+  layout instead of command shims.
+- `uv`-managed Python environment setup.
+- `quick_validate.py --platform auto|claude|codex`.
+- `quick_validate.py --strict-openai-yaml`.
+- `scripts/generate_openai_yaml.py` source-hash stamping.
+- `references/trigger_eval_boundaries.md` for detector false positives,
+  false negatives, `status`, and `attempted_runs`.
+- `references/openai_yaml.md` for Codex metadata authoring constraints.
+
+## Maintenance rules
+
+- When Anthropic changes Claude Code skill frontmatter, locations, packaging, or
+  creator workflow, update the Claude columns and Claude validation branch.
+- When OpenAI changes Codex skill discovery, `agents/openai.yaml`, plugin
+  distribution, or the built-in `skill-creator`, update the Codex columns and
+  Codex validation branch.
+- When skill-forge intentionally diverges from either official creator, record
+  the divergence here before changing scripts or schemas.
+- Do not copy large upstream text into this repository. Keep short summaries and
+  links to primary sources.

--- a/plugins/agent-skills/skills/skill-forge/references/trigger_eval_boundaries.md
+++ b/plugins/agent-skills/skills/skill-forge/references/trigger_eval_boundaries.md
@@ -1,0 +1,90 @@
+# Trigger eval reliability boundaries
+
+Use this reference when running or changing description-trigger evals.
+
+Trigger evals estimate whether a skill description causes the target agent to consult the skill. They are regression signals, not a formal proof of product behavior.
+
+## Result semantics
+
+Each query result has these fields:
+
+- `attempted_runs`: Number of runs requested for the query.
+- `runs`: Number of runs that returned a trigger/non-trigger result without raising.
+- `triggers`: Number of successful runs where the detector saw a trigger signal.
+- `trigger_rate`: `triggers / runs`, or `0.0` when `runs` is `0`.
+- `status`: Execution status.
+  - `ok`: At least one successful run and no run errors.
+  - `partial_error`: At least one successful run and at least one failed run.
+  - `error`: No successful runs and at least one run error.
+  - `not_run`: No successful runs and no run errors, usually because `runs_per_query` was `0`.
+
+A successful non-trigger is `status: "ok"`, `runs > 0`, and `triggers == 0`.
+
+An eval infrastructure failure is `status: "error"` or `status: "not_run"` with `runs == 0`. Treat it as failed even when `should_trigger` is `false`.
+
+## Claude Code detector
+
+The Claude path runs `claude -p <query> --output-format stream-json --verbose --include-partial-messages` with an isolated temporary Claude home.
+
+The detector treats the skill as triggered when either event shape appears:
+
+- Assistant message content item:
+  - `type == "assistant"`
+  - `message.content[].type == "tool_use"`
+  - `name == "Skill"` and `input.skill == <skill-name>`
+- Stream event content block:
+  - `type == "stream_event"`
+  - `event.type == "content_block_start"` with tool `Skill` or `Read`
+  - `event.type == "content_block_delta"` with `delta.type == "input_json_delta"`
+  - accumulated JSON matches either `{"skill": "<skill-name>"}` for `Skill`, or a `Read` `file_path` targeting `skills/<skill-name>/SKILL.md`
+
+### Claude false positives
+
+- A `Read` of the skill's `SKILL.md` counts as triggered. This matches the old practical trigger signal, but it can count manual or diagnostic reads as trigger use.
+- A future Claude event schema that reuses the same fields for a non-invocation preview could be counted as a trigger.
+
+### Claude false negatives
+
+- If Claude consults a skill through a new event type, renamed tool, or non-JSON-delta payload, the detector returns non-trigger.
+- If the CLI emits partial JSON that never becomes valid before the block stops, the detector returns non-trigger.
+- If Claude uses skill content indirectly without a `Skill` tool call or `Read` of `SKILL.md`, the detector cannot see it.
+
+## Codex CLI detector
+
+The Codex path creates a temporary repository skill under `.agents/skills/<skill-name>-skill-<id>/`, keeps the visible SKILL.md `name` as the original skill name, and injects a unique marker into the skill body:
+
+```text
+[SKILL_TRIGGERED:<id>]
+```
+
+It runs `codex exec --json -s read-only -C <project-root> <query>`.
+
+The detector treats the skill as triggered only when:
+
+- `type` is `item.completed` or `item.updated`
+- `item.type == "agent_message"`
+- `item.text` contains the exact marker
+
+`turn.completed` without the marker is a successful non-trigger.
+
+### Codex marker false positives
+
+- If the model quotes or guesses the marker without actually using the skill, the detector counts a trigger.
+- The marker is random per run to make accidental matches unlikely, but it is still visible in the temporary skill body after the skill is read.
+
+### Codex marker false negatives
+
+- If Codex uses the skill but does not follow the marker instruction, the detector returns non-trigger.
+- If Codex emits the marker in a new JSON event shape, such as a renamed message event or nested content field, the detector returns non-trigger until the parser is updated.
+- If the marker appears only in tool output or a transcript field that is not `item.text` for an `agent_message`, the detector returns non-trigger.
+
+## CLI JSON event risk
+
+Both platform paths depend on observed CLI JSON event shapes. A CLI update can change event names, nesting, or payload field names.
+
+When updating parsers, add tests for both:
+
+- The accepted event shape that must trigger.
+- A nearby changed event shape that must not silently become a trigger.
+
+Do not broaden parsing to arbitrary text fields unless the false-positive tradeoff is explicit and tested.

--- a/plugins/agent-skills/skills/skill-forge/scripts/aggregate_benchmark.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/aggregate_benchmark.py
@@ -45,6 +45,13 @@ WORKSPACE_LAYOUT_GLOB = "eval-*"
 LEGACY_LAYOUT_DIRNAME = "runs"
 
 
+def normalize_expectations(grading: dict) -> list:
+    """Return canonical graded expectations, accepting legacy assertions."""
+    if "expectations" in grading:
+        return grading.get("expectations", [])
+    return grading.get("assertions", [])
+
+
 def calculate_stats(values: list[float]) -> dict:
     """Calculate mean, stddev, min, max for a list of values."""
     if not values:
@@ -161,8 +168,10 @@ def load_run_results(benchmark_dir: Path) -> dict:
                     result["tokens"] = metrics.get("output_chars", 0)
                 result["errors"] = metrics.get("errors_encountered", 0)
 
-                # Extract expectations — viewer requires fields: text, passed, evidence
-                raw_expectations = grading.get("expectations", [])
+                # Extract expectations — viewer requires fields: text, passed, evidence.
+                # Legacy grading.json files may use "assertions"; normalize to the
+                # canonical "expectations" field for benchmark.json.
+                raw_expectations = normalize_expectations(grading)
                 for exp in raw_expectations:
                     if "text" not in exp or "passed" not in exp:
                         print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")

--- a/plugins/agent-skills/skills/skill-forge/scripts/ci/verify.sh
+++ b/plugins/agent-skills/skills/skill-forge/scripts/ci/verify.sh
@@ -23,6 +23,7 @@ uv run pytest -m "not integration"
 # ── スキルバリデーション ─────────────────────────────
 echo "==> Validating skill"
 uv run python scripts/quick_validate.py .
+uv run python scripts/quick_validate.py . --platform codex --strict-openai-yaml
 
 echo ""
 echo "All checks passed."

--- a/plugins/agent-skills/skills/skill-forge/scripts/generate_openai_yaml.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/generate_openai_yaml.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Generate Codex agents/openai.yaml metadata for a skill."""
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ACRONYMS = {
+    "AI",
+    "API",
+    "CI",
+    "CLI",
+    "GH",
+    "LLM",
+    "MCP",
+    "PDF",
+    "PR",
+    "SQL",
+    "UI",
+    "URL",
+}
+
+BRANDS = {
+    "codex": "Codex",
+    "github": "GitHub",
+    "openai": "OpenAI",
+    "openapi": "OpenAPI",
+    "sqlite": "SQLite",
+}
+
+SMALL_WORDS = {"and", "for", "in", "of", "or", "to", "up", "with"}
+
+ALLOWED_INTERFACE_KEYS = {
+    "brand_color",
+    "default_prompt",
+    "display_name",
+    "icon_large",
+    "icon_small",
+    "short_description",
+}
+
+
+def yaml_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def read_frontmatter(skill_dir: Path) -> dict:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise ValueError(f"SKILL.md not found in {skill_dir}")
+
+    content = skill_md.read_text()
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        raise ValueError("Invalid SKILL.md frontmatter format")
+
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML frontmatter: {exc}") from exc
+
+    if not isinstance(frontmatter, dict):
+        raise ValueError("Frontmatter must be a YAML dictionary")
+    return frontmatter
+
+
+def format_display_name(skill_name: str) -> str:
+    words = [word for word in skill_name.split("-") if word]
+    formatted = []
+    for index, word in enumerate(words):
+        lower = word.lower()
+        upper = word.upper()
+        if upper in ACRONYMS:
+            formatted.append(upper)
+        elif lower in BRANDS:
+            formatted.append(BRANDS[lower])
+        elif index > 0 and lower in SMALL_WORDS:
+            formatted.append(lower)
+        else:
+            formatted.append(word[:1].upper() + word[1:])
+    return " ".join(formatted)
+
+
+def normalize_short_description(description: str, display_name: str) -> str:
+    text = " ".join(description.split())
+    text = text.rstrip(".")
+
+    if 25 <= len(text) <= 64:
+        return text
+
+    fallback = f"Use {display_name} workflows in Codex"
+    if 25 <= len(fallback) <= 64:
+        return fallback
+
+    compact = f"{display_name} workflow helper"
+    if len(compact) < 25:
+        compact = f"{compact} for Codex"
+    if len(compact) > 64:
+        compact = compact[:64].rstrip()
+    return compact
+
+
+def default_prompt_for(skill_name: str, description: str) -> str:
+    text = " ".join(description.split()).rstrip(".")
+    if not text:
+        return f"Use ${skill_name} to help with this task."
+    lower = text.lower()
+    for prefix in ("use this skill when ", "use when "):
+        if lower.startswith(prefix):
+            body = text[len(prefix):].strip()
+            return f"Use ${skill_name} when {body[:96].rstrip()}."
+    return f"Use ${skill_name} to {text[:96].rstrip()}."
+
+
+def parse_interface_overrides(raw_overrides: list[str]) -> dict[str, str]:
+    overrides = {}
+    for item in raw_overrides:
+        if "=" not in item:
+            raise ValueError(f"Invalid interface override '{item}'. Use key=value.")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key not in ALLOWED_INTERFACE_KEYS:
+            allowed = ", ".join(sorted(ALLOWED_INTERFACE_KEYS))
+            raise ValueError(f"Unknown interface field '{key}'. Allowed: {allowed}")
+        overrides[key] = value
+    return overrides
+
+
+def build_openai_yaml(skill_dir: Path, raw_overrides: list[str] | None = None) -> str:
+    frontmatter = read_frontmatter(skill_dir)
+    skill_name = frontmatter.get("name")
+    description = frontmatter.get("description", "")
+    if not isinstance(skill_name, str) or not skill_name.strip():
+        raise ValueError("Frontmatter 'name' is missing or invalid")
+    if not isinstance(description, str):
+        raise ValueError("Frontmatter 'description' must be a string")
+
+    skill_name = skill_name.strip()
+    description = description.strip()
+    overrides = parse_interface_overrides(raw_overrides or [])
+
+    display_name = overrides.get("display_name") or format_display_name(skill_name)
+    short_description = overrides.get("short_description") or normalize_short_description(
+        description,
+        display_name,
+    )
+    default_prompt = overrides.get("default_prompt") or default_prompt_for(skill_name, description)
+
+    if not display_name.strip():
+        raise ValueError("display_name must not be empty")
+    if not 25 <= len(short_description) <= 64:
+        raise ValueError(f"short_description must be 25-64 characters (got {len(short_description)})")
+    if f"${skill_name}" not in default_prompt:
+        raise ValueError(f"default_prompt must mention ${skill_name}")
+
+    interface = {
+        "display_name": display_name,
+        "short_description": short_description,
+        "default_prompt": default_prompt,
+    }
+    for key in ("icon_small", "icon_large", "brand_color"):
+        if key in overrides:
+            interface[key] = overrides[key]
+
+    source_hash = hashlib.sha256((skill_dir / "SKILL.md").read_bytes()).hexdigest()
+    lines = [
+        f"# skill-forge-source-sha256: {source_hash}",
+        "interface:",
+    ]
+    for key, value in interface.items():
+        lines.append(f"  {key}: {yaml_quote(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def write_openai_yaml(skill_dir: Path, raw_overrides: list[str] | None = None) -> Path:
+    content = build_openai_yaml(skill_dir, raw_overrides)
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    output_path = agents_dir / "openai.yaml"
+    output_path.write_text(content)
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create agents/openai.yaml for a skill directory")
+    parser.add_argument("skill_dir", help="Path to the skill directory")
+    parser.add_argument(
+        "--interface",
+        action="append",
+        default=[],
+        help="Interface override in key=value format. Repeat for multiple fields.",
+    )
+    args = parser.parse_args()
+
+    skill_dir = Path(args.skill_dir).resolve()
+    if not skill_dir.exists():
+        print(f"[ERROR] Skill directory not found: {skill_dir}", file=sys.stderr)
+        return 1
+    if not skill_dir.is_dir():
+        print(f"[ERROR] Path is not a directory: {skill_dir}", file=sys.stderr)
+        return 1
+
+    try:
+        output_path = write_openai_yaml(skill_dir, args.interface)
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+    print(f"[OK] Created {output_path.relative_to(skill_dir)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agent-skills/skills/skill-forge/scripts/quick_validate.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/quick_validate.py
@@ -2,6 +2,7 @@
 """Quick validation script for skills."""
 
 import argparse
+import hashlib
 import sys
 import re
 import yaml
@@ -49,6 +50,7 @@ OPENAI_YAML_INTERFACE_KEYS = {
 OPENAI_YAML_POLICY_KEYS = {"allow_implicit_invocation"}
 OPENAI_YAML_DEPENDENCIES_KEYS = {"tools"}
 OPENAI_YAML_TOOL_KEYS = {"type", "value", "description", "transport", "url"}
+OPENAI_YAML_SOURCE_HASH_PATTERN = re.compile(r"^# skill-forge-source-sha256: ([a-f0-9]{64})\n")
 
 
 def _allowed_properties(platform: str) -> set[str]:
@@ -59,13 +61,32 @@ def _allowed_properties(platform: str) -> set[str]:
     return CLAUDE_PROPERTIES | CODEX_PROPERTIES
 
 
-def _validate_openai_yaml(skill_path: Path) -> tuple[bool, str]:
+def _validate_openai_yaml(
+    skill_path: Path,
+    skill_name: str,
+    strict_openai_yaml: bool = False,
+) -> tuple[bool, str]:
     openai_yaml = skill_path / "agents" / "openai.yaml"
     if not openai_yaml.exists():
+        if strict_openai_yaml:
+            return False, "agents/openai.yaml not found"
         return True, ""
 
+    skill_md = skill_path / "SKILL.md"
+    openai_yaml_text = openai_yaml.read_text()
+    if strict_openai_yaml:
+        source_hash_match = OPENAI_YAML_SOURCE_HASH_PATTERN.match(openai_yaml_text)
+        if not source_hash_match:
+            return False, (
+                "agents/openai.yaml is missing skill-forge source hash. "
+                "Regenerate metadata after updating the skill."
+            )
+        source_hash = hashlib.sha256(skill_md.read_bytes()).hexdigest()
+        if source_hash_match.group(1) != source_hash:
+            return False, "agents/openai.yaml is stale. Regenerate metadata after updating SKILL.md."
+
     try:
-        metadata = yaml.safe_load(openai_yaml.read_text())
+        metadata = yaml.safe_load(openai_yaml_text)
     except yaml.YAMLError as e:
         return False, f"Invalid YAML in agents/openai.yaml: {e}"
 
@@ -98,6 +119,25 @@ def _validate_openai_yaml(skill_path: Path) -> tuple[bool, str]:
         for key, value in interface.items():
             if value is not None and not isinstance(value, str):
                 return False, f"agents/openai.yaml interface.{key} must be a string"
+
+        if strict_openai_yaml:
+            for key in ("display_name", "short_description", "default_prompt"):
+                value = interface.get(key)
+                if not isinstance(value, str) or not value.strip():
+                    return False, f"agents/openai.yaml interface.{key} is required in strict mode"
+
+            short_description = interface["short_description"]
+            if not 25 <= len(short_description) <= 64:
+                return False, (
+                    "agents/openai.yaml interface.short_description must be 25-64 characters "
+                    f"(got {len(short_description)})"
+                )
+
+            default_prompt = interface["default_prompt"]
+            if f"${skill_name}" not in default_prompt:
+                return False, f"agents/openai.yaml interface.default_prompt must mention ${skill_name}"
+    elif strict_openai_yaml:
+        return False, "agents/openai.yaml interface is required in strict mode"
 
     policy = metadata.get("policy")
     if policy is not None:
@@ -149,7 +189,7 @@ def _validate_openai_yaml(skill_path: Path) -> tuple[bool, str]:
     return True, ""
 
 
-def validate_skill(skill_path, platform=PLATFORM_AUTO):
+def validate_skill(skill_path, platform=PLATFORM_AUTO, strict_openai_yaml=False):
     """Basic validation of a skill"""
     if platform not in PLATFORMS:
         return False, f"Unknown platform '{platform}'. Use one of: {', '.join(sorted(PLATFORMS))}"
@@ -234,7 +274,11 @@ def validate_skill(skill_path, platform=PLATFORM_AUTO):
             return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
 
     if platform in (PLATFORM_AUTO, PLATFORM_CODEX):
-        valid, message = _validate_openai_yaml(skill_path)
+        valid, message = _validate_openai_yaml(
+            skill_path,
+            skill_name=name,
+            strict_openai_yaml=strict_openai_yaml,
+        )
         if not valid:
             return valid, message
 
@@ -249,8 +293,17 @@ if __name__ == "__main__":
         default=PLATFORM_AUTO,
         help="Validation target. Default 'auto' accepts Claude and Codex frontmatter and validates agents/openai.yaml when present.",
     )
+    parser.add_argument(
+        "--strict-openai-yaml",
+        action="store_true",
+        help="Require fresh Codex agents/openai.yaml metadata with display_name, short_description, and default_prompt.",
+    )
     args = parser.parse_args()
 
-    valid, message = validate_skill(args.skill_directory, platform=args.platform)
+    valid, message = validate_skill(
+        args.skill_directory,
+        platform=args.platform,
+        strict_openai_yaml=args.strict_openai_yaml,
+    )
     print(message)
     sys.exit(0 if valid else 1)

--- a/plugins/agent-skills/skills/skill-forge/scripts/quick_validate.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/quick_validate.py
@@ -1,16 +1,159 @@
 #!/usr/bin/env python3
-"""
-Quick validation script for skills - minimal version
-"""
+"""Quick validation script for skills."""
 
+import argparse
 import sys
-import os
 import re
 import yaml
 from pathlib import Path
 
-def validate_skill(skill_path):
+PLATFORM_AUTO = "auto"
+PLATFORM_CLAUDE = "claude"
+PLATFORM_CODEX = "codex"
+PLATFORMS = {PLATFORM_AUTO, PLATFORM_CLAUDE, PLATFORM_CODEX}
+
+COMMON_PROPERTIES = {"name", "description", "license", "metadata"}
+
+CLAUDE_PROPERTIES = COMMON_PROPERTIES | {
+    "agent",
+    "allowed-tools",
+    "argument-hint",
+    "arguments",
+    "compatibility",
+    "context",
+    "disable-model-invocation",
+    "disallowed-tools",
+    "effort",
+    "hooks",
+    "model",
+    "paths",
+    "shell",
+    "user-invocable",
+    "when_to_use",
+}
+
+CODEX_PROPERTIES = COMMON_PROPERTIES | {
+    "allowed-tools",
+    "compatibility",
+}
+
+OPENAI_YAML_TOP_LEVEL_KEYS = {"interface", "dependencies", "policy"}
+OPENAI_YAML_INTERFACE_KEYS = {
+    "brand_color",
+    "default_prompt",
+    "display_name",
+    "icon_large",
+    "icon_small",
+    "short_description",
+}
+OPENAI_YAML_POLICY_KEYS = {"allow_implicit_invocation"}
+OPENAI_YAML_DEPENDENCIES_KEYS = {"tools"}
+OPENAI_YAML_TOOL_KEYS = {"type", "value", "description", "transport", "url"}
+
+
+def _allowed_properties(platform: str) -> set[str]:
+    if platform == PLATFORM_CLAUDE:
+        return CLAUDE_PROPERTIES
+    if platform == PLATFORM_CODEX:
+        return CODEX_PROPERTIES
+    return CLAUDE_PROPERTIES | CODEX_PROPERTIES
+
+
+def _validate_openai_yaml(skill_path: Path) -> tuple[bool, str]:
+    openai_yaml = skill_path / "agents" / "openai.yaml"
+    if not openai_yaml.exists():
+        return True, ""
+
+    try:
+        metadata = yaml.safe_load(openai_yaml.read_text())
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in agents/openai.yaml: {e}"
+
+    if not isinstance(metadata, dict):
+        return False, "agents/openai.yaml must be a YAML dictionary"
+
+    unexpected_keys = set(metadata.keys()) - OPENAI_YAML_TOP_LEVEL_KEYS
+    if unexpected_keys:
+        allowed = ", ".join(sorted(OPENAI_YAML_TOP_LEVEL_KEYS))
+        unexpected = ", ".join(sorted(unexpected_keys))
+        return False, (
+            f"Unexpected key(s) in agents/openai.yaml: {unexpected}. "
+            f"Allowed properties are: {allowed}"
+        )
+
+    interface = metadata.get("interface")
+    if interface is not None:
+        if not isinstance(interface, dict):
+            return False, "agents/openai.yaml interface must be a YAML dictionary"
+
+        unexpected_interface_keys = set(interface.keys()) - OPENAI_YAML_INTERFACE_KEYS
+        if unexpected_interface_keys:
+            allowed = ", ".join(sorted(OPENAI_YAML_INTERFACE_KEYS))
+            unexpected = ", ".join(sorted(unexpected_interface_keys))
+            return False, (
+                f"Unexpected key(s) in agents/openai.yaml interface: {unexpected}. "
+                f"Allowed properties are: {allowed}"
+            )
+
+        for key, value in interface.items():
+            if value is not None and not isinstance(value, str):
+                return False, f"agents/openai.yaml interface.{key} must be a string"
+
+    policy = metadata.get("policy")
+    if policy is not None:
+        if not isinstance(policy, dict):
+            return False, "agents/openai.yaml policy must be a YAML dictionary"
+        unexpected_policy_keys = set(policy.keys()) - OPENAI_YAML_POLICY_KEYS
+        if unexpected_policy_keys:
+            allowed = ", ".join(sorted(OPENAI_YAML_POLICY_KEYS))
+            unexpected = ", ".join(sorted(unexpected_policy_keys))
+            return False, (
+                f"Unexpected key(s) in agents/openai.yaml policy: {unexpected}. "
+                f"Allowed properties are: {allowed}"
+            )
+        allow_implicit_invocation = policy.get("allow_implicit_invocation")
+        if allow_implicit_invocation is not None and not isinstance(allow_implicit_invocation, bool):
+            return False, "agents/openai.yaml policy.allow_implicit_invocation must be a boolean"
+
+    dependencies = metadata.get("dependencies")
+    if dependencies is not None:
+        if not isinstance(dependencies, dict):
+            return False, "agents/openai.yaml dependencies must be a YAML dictionary"
+        unexpected_dependencies_keys = set(dependencies.keys()) - OPENAI_YAML_DEPENDENCIES_KEYS
+        if unexpected_dependencies_keys:
+            allowed = ", ".join(sorted(OPENAI_YAML_DEPENDENCIES_KEYS))
+            unexpected = ", ".join(sorted(unexpected_dependencies_keys))
+            return False, (
+                f"Unexpected key(s) in agents/openai.yaml dependencies: {unexpected}. "
+                f"Allowed properties are: {allowed}"
+            )
+        tools = dependencies.get("tools")
+        if tools is not None:
+            if not isinstance(tools, list):
+                return False, "agents/openai.yaml dependencies.tools must be a YAML list"
+            for index, tool in enumerate(tools):
+                if not isinstance(tool, dict):
+                    return False, f"agents/openai.yaml dependencies.tools[{index}] must be a YAML dictionary"
+                unexpected_tool_keys = set(tool.keys()) - OPENAI_YAML_TOOL_KEYS
+                if unexpected_tool_keys:
+                    allowed = ", ".join(sorted(OPENAI_YAML_TOOL_KEYS))
+                    unexpected = ", ".join(sorted(unexpected_tool_keys))
+                    return False, (
+                        f"Unexpected key(s) in agents/openai.yaml dependencies.tools[{index}]: {unexpected}. "
+                        f"Allowed properties are: {allowed}"
+                    )
+                for key, value in tool.items():
+                    if value is not None and not isinstance(value, str):
+                        return False, f"agents/openai.yaml dependencies.tools[{index}].{key} must be a string"
+
+    return True, ""
+
+
+def validate_skill(skill_path, platform=PLATFORM_AUTO):
     """Basic validation of a skill"""
+    if platform not in PLATFORMS:
+        return False, f"Unknown platform '{platform}'. Use one of: {', '.join(sorted(PLATFORMS))}"
+
     skill_path = Path(skill_path)
 
     # Check SKILL.md exists
@@ -38,15 +181,14 @@ def validate_skill(skill_path):
     except yaml.YAMLError as e:
         return False, f"Invalid YAML in frontmatter: {e}"
 
-    # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+    allowed_properties = _allowed_properties(platform)
 
     # Check for unexpected properties (excluding nested keys under metadata)
-    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    unexpected_keys = set(frontmatter.keys()) - allowed_properties
     if unexpected_keys:
         return False, (
             f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
-            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+            f"Allowed properties for platform '{platform}' are: {', '.join(sorted(allowed_properties))}"
         )
 
     # Check required fields
@@ -61,9 +203,9 @@ def validate_skill(skill_path):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
     if name:
-        # Check naming convention (kebab-case: lowercase with hyphens)
-        if not re.match(r'^[a-z0-9-]+$', name):
-            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        # Codex bundled skills include uppercase display-like names; keep path-unsafe characters out.
+        if not re.match(r'^[A-Za-z0-9-]+$', name):
+            return False, f"Name '{name}' should use letters, digits, and hyphens only"
         if name.startswith('-') or name.endswith('-') or '--' in name:
             return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
         # Check name length (max 64 characters per spec)
@@ -91,13 +233,24 @@ def validate_skill(skill_path):
         if len(compatibility) > 500:
             return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
 
+    if platform in (PLATFORM_AUTO, PLATFORM_CODEX):
+        valid, message = _validate_openai_yaml(skill_path)
+        if not valid:
+            return valid, message
+
     return True, "Skill is valid!"
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python quick_validate.py <skill_directory>")
-        sys.exit(1)
-    
-    valid, message = validate_skill(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Validate a skill directory")
+    parser.add_argument("skill_directory", help="Path to the skill directory")
+    parser.add_argument(
+        "--platform",
+        choices=sorted(PLATFORMS),
+        default=PLATFORM_AUTO,
+        help="Validation target. Default 'auto' accepts Claude and Codex frontmatter and validates agents/openai.yaml when present.",
+    )
+    args = parser.parse_args()
+
+    valid, message = validate_skill(args.skill_directory, platform=args.platform)
     print(message)
     sys.exit(0 if valid else 1)

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
@@ -58,10 +58,17 @@ def run_eval(
 ) -> dict:
     """Run the full eval set and return results."""
     results = []
+    query_triggers: dict[str, list[bool]] = {}
+    query_errors: dict[str, list[str]] = {}
+    query_items: dict[str, dict] = {}
 
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         future_to_info = {}
         for item in eval_set:
+            query = item["query"]
+            query_triggers.setdefault(query, [])
+            query_errors.setdefault(query, [])
+            query_items[query] = item
             for run_idx in range(runs_per_query):
                 future = executor.submit(
                     run_single_query,
@@ -76,16 +83,9 @@ def run_eval(
                 )
                 future_to_info[future] = (item, run_idx)
 
-        query_triggers: dict[str, list[bool]] = {}
-        query_errors: dict[str, list[str]] = {}
-        query_items: dict[str, dict] = {}
         for future in as_completed(future_to_info):
             item, _ = future_to_info[future]
             query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-                query_errors[query] = []
             try:
                 query_triggers[query].append(future.result())
             except Exception as e:
@@ -113,14 +113,24 @@ def run_eval(
             did_pass = trigger_rate >= trigger_threshold
         else:
             did_pass = trigger_rate < trigger_threshold
-        if effective_runs == 0 and errors:
+        if effective_runs == 0:
             did_pass = False
+        if effective_runs == 0 and errors:
+            status = "error"
+        elif effective_runs == 0:
+            status = "not_run"
+        elif errors:
+            status = "partial_error"
+        else:
+            status = "ok"
         result_entry: dict = {
             "query": query,
             "should_trigger": should_trigger,
             "trigger_rate": trigger_rate,
             "triggers": sum(triggers),
             "runs": effective_runs,
+            "attempted_runs": runs_per_query,
+            "status": status,
             "pass": did_pass,
         }
         if errors:

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval_claude.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval_claude.py
@@ -16,33 +16,39 @@ def _is_expected_claude_tool_input(
     tool_name: str,
     tool_input: dict,
     skill_name: str,
-    command_name: str,
     skills_dir: Path,
-    commands_dir: Path,
 ) -> bool:
     """Return True when a Claude tool call targets the skill under test."""
     if tool_name == "Skill":
-        return tool_input.get("skill", "") in (skill_name, command_name)
+        return tool_input.get("skill", "") == skill_name
 
     if tool_name == "Read":
         file_path = tool_input.get("file_path", "")
-        expected_paths = (
-            skills_dir / skill_name / "SKILL.md",
-            commands_dir / f"{command_name}.md",
-        )
-        expected_suffixes = (
-            Path("skills") / skill_name / "SKILL.md",
-            Path("commands") / f"{command_name}.md",
-        )
+        expected_path = skills_dir / skill_name / "SKILL.md"
+        expected_suffix = Path("skills") / skill_name / "SKILL.md"
         normalized_file_path = file_path.replace("\\", "/")
-        return any(
-            normalized_file_path == str(path).replace("\\", "/")
-            or normalized_file_path.endswith(str(path).replace("\\", "/"))
-            or normalized_file_path.endswith(str(suffix).replace("\\", "/"))
-            for path, suffix in zip(expected_paths, expected_suffixes, strict=True)
+        return (
+            normalized_file_path == str(expected_path).replace("\\", "/")
+            or normalized_file_path.endswith(str(expected_path).replace("\\", "/"))
+            or normalized_file_path.endswith(str(expected_suffix).replace("\\", "/"))
         )
 
     return False
+
+
+def _write_skill_under_test(skill_file: Path, skill_name: str, skill_description: str) -> None:
+    """Write a real SKILL.md for the description under test."""
+    indented_desc = "\n  ".join(skill_description.split("\n"))
+    skill_content = (
+        f"---\n"
+        f"name: {skill_name}\n"
+        f"description: |\n"
+        f"  {indented_desc}\n"
+        f"---\n\n"
+        f"# {skill_name}\n\n"
+        f"This skill handles: {skill_description}\n"
+    )
+    skill_file.write_text(skill_content)
 
 
 def run_single_query_claude(
@@ -58,27 +64,17 @@ def run_single_query_claude(
     project_root_path = Path(project_root)
     source_skills_dir = resolve_skill_dir(CLI_CLAUDE, project_root_path)
     temp_claude_home = Path(tempfile.mkdtemp(prefix="skill-forge-claude-home-", dir=project_root_path))
-    temp_commands_dir = temp_claude_home / "commands"
     temp_skills_dir = temp_claude_home / "skills"
-    command_name = skill_name
-    command_file = temp_commands_dir / f"{command_name}.md"
+    temp_skill_dir = temp_skills_dir / skill_name
+    skill_file = temp_skill_dir / "SKILL.md"
 
     try:
-        temp_commands_dir.mkdir(parents=True, exist_ok=True)
         source_skill_dir = source_skills_dir / skill_name
         if source_skill_dir.exists():
-            shutil.copytree(source_skill_dir, temp_skills_dir / skill_name)
-
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            f"---\n"
-            f"description: |\n"
-            f"  {indented_desc}\n"
-            f"---\n\n"
-            f"# {skill_name}\n\n"
-            f"This skill handles: {skill_description}\n"
-        )
-        command_file.write_text(command_content)
+            shutil.copytree(source_skill_dir, temp_skill_dir)
+        else:
+            temp_skill_dir.mkdir(parents=True, exist_ok=True)
+        _write_skill_under_test(skill_file, skill_name, skill_description)
 
         cmd = [
             get_cli_command(CLI_CLAUDE, cli_command),
@@ -92,6 +88,7 @@ def run_single_query_claude(
 
         env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
         env["SKILL_FORGE_CLAUDE_HOME"] = str(temp_claude_home)
+        env["CLAUDE_CONFIG_DIR"] = str(temp_claude_home)
 
         process = subprocess.Popen(
             cmd,
@@ -159,9 +156,7 @@ def run_single_query_claude(
                                     pending_tool_name,
                                     tool_input,
                                     skill_name,
-                                    command_name,
                                     temp_skills_dir,
-                                    temp_commands_dir,
                                 ):
                                     return True
 
@@ -175,9 +170,7 @@ def run_single_query_claude(
                                     pending_tool_name,
                                     tool_input,
                                     skill_name,
-                                    command_name,
                                     temp_skills_dir,
-                                    temp_commands_dir,
                                 ):
                                     return True
                                 pending_tool_name = None
@@ -192,9 +185,7 @@ def run_single_query_claude(
                                 content_item.get("name", ""),
                                 content_item.get("input", {}),
                                 skill_name,
-                                command_name,
                                 temp_skills_dir,
-                                temp_commands_dir,
                             ):
                                 triggered = True
                                 return True

--- a/plugins/agent-skills/skills/skill-forge/scripts/utils.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/utils.py
@@ -100,6 +100,9 @@ def resolve_cli_home(cli_type: str, project_root: Path | None = None) -> Path:
 
 def resolve_skill_dir(cli_type: str, project_root: Path | None = None) -> Path:
     """Resolve the effective skills directory for the CLI."""
+    if cli_type == CLI_CODEX:
+        base_root = project_root if project_root is not None else find_project_root(cli_type)
+        return base_root / ".agents" / "skills"
     return resolve_cli_home(cli_type, project_root) / "skills"
 
 

--- a/plugins/agent-skills/skills/skill-forge/tests/test_aggregate_benchmark.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_aggregate_benchmark.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from scripts.aggregate_benchmark import load_run_results
+from scripts.aggregate_benchmark import generate_benchmark, load_run_results, normalize_expectations
 
 
 class TestLoadRunResults:
@@ -21,3 +21,32 @@ class TestLoadRunResults:
 
         with pytest.raises(ValueError, match="Both workspace and legacy benchmark layouts exist"):
             load_run_results(tmp_path)
+
+    def test_legacy_assertions_are_normalized_to_expectations(self, tmp_path):
+        run_dir = tmp_path / "eval-0" / "with_skill" / "run-1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "grading.json").write_text(
+            """
+            {
+              "summary": {"pass_rate": 1.0, "passed": 1, "failed": 0, "total": 1},
+              "assertions": [
+                {"text": "Output includes summary", "passed": true, "evidence": "summary.md"}
+              ]
+            }
+            """
+        )
+
+        benchmark = generate_benchmark(tmp_path, skill_name="test-skill")
+
+        assert benchmark["runs"][0]["expectations"] == [
+            {"text": "Output includes summary", "passed": True, "evidence": "summary.md"}
+        ]
+        assert "assertions" not in benchmark["runs"][0]
+
+    def test_expectations_take_precedence_over_legacy_assertions(self):
+        grading = {
+            "expectations": [{"text": "canonical", "passed": True}],
+            "assertions": [{"text": "legacy", "passed": False}],
+        }
+
+        assert normalize_expectations(grading) == [{"text": "canonical", "passed": True}]

--- a/plugins/agent-skills/skills/skill-forge/tests/test_generate_openai_yaml.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_generate_openai_yaml.py
@@ -1,0 +1,124 @@
+"""Tests for scripts.generate_openai_yaml module."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.generate_openai_yaml import (
+    build_openai_yaml,
+    default_prompt_for,
+    format_display_name,
+    write_openai_yaml,
+)
+from scripts.quick_validate import validate_skill
+
+
+def write_skill(skill_dir: Path, name: str = "test-skill", description: str = "") -> None:
+    if not description:
+        description = "Use when the user wants focused test workflow assistance."
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# Test\n"
+    )
+
+
+class TestOpenAiYamlGeneration:
+    def test_format_display_name_preserves_common_acronyms_and_brands(self):
+        assert format_display_name("openai-api-helper") == "OpenAI API Helper"
+        assert format_display_name("github-pr-review") == "GitHub PR Review"
+
+    def test_build_openai_yaml_generates_required_interface_fields(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+
+        content = build_openai_yaml(tmp_path)
+        metadata = yaml.safe_load(content)
+
+        assert content.startswith("# skill-forge-source-sha256: ")
+        assert metadata["interface"]["display_name"] == "Test Skill"
+        assert 25 <= len(metadata["interface"]["short_description"]) <= 64
+        assert "$test-skill" in metadata["interface"]["default_prompt"]
+
+    def test_default_prompt_turns_use_when_description_into_invocation_prompt(self):
+        prompt = default_prompt_for("test-skill", "Use when the user wants focused help.")
+
+        assert prompt == "Use $test-skill when the user wants focused help."
+
+    def test_build_openai_yaml_accepts_interface_overrides(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+
+        content = build_openai_yaml(
+            tmp_path,
+            [
+                "display_name=Custom Skill",
+                "short_description=Custom skill workflow helper",
+                "default_prompt=Use $test-skill for this workflow.",
+                "brand_color=#3B82F6",
+            ],
+        )
+        metadata = yaml.safe_load(content)
+
+        assert metadata["interface"]["display_name"] == "Custom Skill"
+        assert metadata["interface"]["short_description"] == "Custom skill workflow helper"
+        assert metadata["interface"]["default_prompt"] == "Use $test-skill for this workflow."
+        assert metadata["interface"]["brand_color"] == "#3B82F6"
+
+    def test_build_openai_yaml_rejects_short_description_outside_constraints(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+
+        with pytest.raises(ValueError, match="short_description must be 25-64 characters"):
+            build_openai_yaml(tmp_path, ["short_description=Too short"])
+
+    def test_build_openai_yaml_rejects_default_prompt_without_skill_invocation(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+
+        with pytest.raises(ValueError, match=r"default_prompt must mention \$test-skill"):
+            build_openai_yaml(tmp_path, ["default_prompt=Use this helper."])
+
+
+class TestStrictOpenAiYamlValidation:
+    def test_strict_validation_accepts_generated_openai_yaml(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+        write_openai_yaml(tmp_path)
+
+        valid, message = validate_skill(
+            tmp_path,
+            platform="codex",
+            strict_openai_yaml=True,
+        )
+
+        assert valid is True
+        assert message == "Skill is valid!"
+
+    def test_strict_validation_requires_openai_yaml(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+
+        valid, message = validate_skill(
+            tmp_path,
+            platform="codex",
+            strict_openai_yaml=True,
+        )
+
+        assert valid is False
+        assert message == "agents/openai.yaml not found"
+
+    def test_strict_validation_detects_stale_openai_yaml(self, tmp_path):
+        write_skill(tmp_path, name="test-skill")
+        write_openai_yaml(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "---\n"
+            "name: test-skill\n"
+            "description: Use when the user wants updated workflow assistance.\n"
+            "---\n\n"
+            "# Test\n"
+        )
+
+        valid, message = validate_skill(
+            tmp_path,
+            platform="codex",
+            strict_openai_yaml=True,
+        )
+
+        assert valid is False
+        assert "agents/openai.yaml is stale" in message

--- a/plugins/agent-skills/skills/skill-forge/tests/test_quick_validate.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_quick_validate.py
@@ -1,0 +1,178 @@
+"""Tests for scripts.quick_validate module."""
+
+from pathlib import Path
+
+from scripts.quick_validate import validate_skill
+
+
+def write_skill(skill_dir: Path, frontmatter: str = "") -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    if not frontmatter:
+        frontmatter = (
+            "name: test-skill\n"
+            "description: Test skill\n"
+        )
+    (skill_dir / "SKILL.md").write_text(f"---\n{frontmatter}---\n\n# Test\n")
+
+
+class TestPlatformFrontmatter:
+    def test_auto_accepts_claude_frontmatter(self, tmp_path):
+        write_skill(
+            tmp_path,
+            "name: test-skill\n"
+            "description: Test skill\n"
+            "disable-model-invocation: true\n"
+            "user-invocable: false\n"
+            "when_to_use: Use for tests\n"
+            "argument-hint: '[file]'\n",
+        )
+
+        valid, message = validate_skill(tmp_path)
+
+        assert valid is True
+        assert message == "Skill is valid!"
+
+    def test_claude_accepts_latest_frontmatter_keys(self, tmp_path):
+        write_skill(
+            tmp_path,
+            "name: test-skill\n"
+            "description: Test skill\n"
+            "allowed-tools: Read, Bash\n"
+            "disallowed-tools: WebFetch\n"
+            "disable-model-invocation: true\n"
+            "user-invocable: true\n"
+            "when_to_use: Use for tests\n"
+            "argument-hint: '[file]'\n"
+            "arguments:\n"
+            "  file: Required path\n"
+            "model: claude-sonnet-4-5\n"
+            "effort: high\n"
+            "context: fork\n"
+            "agent: reviewer\n"
+            "hooks:\n"
+            "  Stop: echo done\n"
+            "paths:\n"
+            "  - '**/*.py'\n"
+            "shell: bash\n",
+        )
+
+        valid, message = validate_skill(tmp_path, platform="claude")
+
+        assert valid is True
+        assert message == "Skill is valid!"
+
+    def test_codex_rejects_claude_only_frontmatter(self, tmp_path):
+        write_skill(
+            tmp_path,
+            "name: test-skill\n"
+            "description: Test skill\n"
+            "disable-model-invocation: true\n",
+        )
+
+        valid, message = validate_skill(tmp_path, platform="codex")
+
+        assert valid is False
+        assert "disable-model-invocation" in message
+        assert "platform 'codex'" in message
+
+    def test_codex_accepts_builtin_style_uppercase_name(self, tmp_path):
+        write_skill(
+            tmp_path,
+            'name: "Spreadsheets"\n'
+            'description: Test skill\n',
+        )
+
+        valid, message = validate_skill(tmp_path, platform="codex")
+
+        assert valid is True
+        assert message == "Skill is valid!"
+
+    def test_unknown_platform_returns_error(self, tmp_path):
+        write_skill(tmp_path)
+
+        valid, message = validate_skill(tmp_path, platform="other")
+
+        assert valid is False
+        assert "Unknown platform" in message
+
+
+class TestOpenAiYaml:
+    def test_codex_validates_openai_yaml_when_present(self, tmp_path):
+        write_skill(tmp_path)
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "openai.yaml").write_text(
+            'interface:\n'
+            '  display_name: "Test Skill"\n'
+            '  short_description: "Test helper"\n'
+            '  default_prompt: "Use $test-skill to do the task."\n'
+            'policy:\n'
+            '  allow_implicit_invocation: true\n'
+            'dependencies:\n'
+            '  tools:\n'
+            '    - type: "mcp"\n'
+            '      value: "github"\n'
+            '      description: "GitHub MCP server"\n'
+            '      transport: "streamable_http"\n'
+            '      url: "https://example.com/mcp/"\n'
+        )
+
+        valid, message = validate_skill(tmp_path, platform="codex")
+
+        assert valid is True
+        assert message == "Skill is valid!"
+
+    def test_codex_rejects_invalid_openai_yaml_interface_value(self, tmp_path):
+        write_skill(tmp_path)
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "openai.yaml").write_text(
+            'interface:\n'
+            '  display_name: 123\n'
+        )
+
+        valid, message = validate_skill(tmp_path, platform="codex")
+
+        assert valid is False
+        assert "interface.display_name must be a string" in message
+
+    def test_auto_validates_openai_yaml_when_present(self, tmp_path):
+        write_skill(tmp_path)
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "openai.yaml").write_text("unexpected: true\n")
+
+        valid, message = validate_skill(tmp_path)
+
+        assert valid is False
+        assert "Unexpected key(s) in agents/openai.yaml" in message
+
+    def test_codex_rejects_invalid_openai_yaml_policy_value(self, tmp_path):
+        write_skill(tmp_path)
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "openai.yaml").write_text(
+            'policy:\n'
+            '  allow_implicit_invocation: "yes"\n'
+        )
+
+        valid, message = validate_skill(tmp_path, platform="codex")
+
+        assert valid is False
+        assert "policy.allow_implicit_invocation must be a boolean" in message
+
+    def test_codex_rejects_invalid_openai_yaml_dependency_tool_value(self, tmp_path):
+        write_skill(tmp_path)
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "openai.yaml").write_text(
+            'dependencies:\n'
+            '  tools:\n'
+            '    - type: "mcp"\n'
+            '      value: ["github"]\n'
+        )
+
+        valid, message = validate_skill(tmp_path, platform="codex")
+
+        assert valid is False
+        assert "dependencies.tools[0].value must be a string" in message

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
@@ -63,7 +63,7 @@ class TestCodexCommandArgs:
     def test_no_invalid_approval_flag(self, tmp_path):
         """Ensure -a flag is not used (removed in current codex CLI)."""
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         captured_cmd = []
 
@@ -88,7 +88,7 @@ class TestCodexCommandArgs:
     def test_codex_command_includes_required_flags(self, tmp_path):
         """Verify codex exec includes --json, -s, -C flags."""
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         captured_cmd = []
 
@@ -119,7 +119,7 @@ class TestCliExitCodeHandling:
 
     def test_codex_nonzero_exit_raises(self, tmp_path):
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         mock_process = MagicMock()
         mock_process.poll.side_effect = [0, 0]
@@ -385,7 +385,7 @@ class TestRunSingleQueryCodex:
     def test_creates_and_cleans_temp_skill(self, tmp_path):
         """Verify temp skill dir is created and cleaned up."""
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         events = [
             json.dumps({"type": "turn.completed", "usage": {}}),
@@ -400,10 +400,10 @@ class TestRunSingleQueryCodex:
 
         assert result is False
         # Temp skill dir should be cleaned up
-        skill_dirs = list((project_root / ".codex" / "skills").iterdir())
+        skill_dirs = list((project_root / ".agents" / "skills").iterdir())
         assert len(skill_dirs) == 0
 
-    def test_creates_and_cleans_temp_skill_in_codex_home_override(self, tmp_path):
+    def test_creates_temp_skill_in_repo_agents_even_with_codex_home_override(self, tmp_path):
         project_root = tmp_path / "project"
         project_root.mkdir(parents=True)
         codex_home = tmp_path / "custom-codex-home"
@@ -421,14 +421,15 @@ class TestRunSingleQueryCodex:
                     )
 
         assert result is False
-        assert (codex_home / "skills").is_dir()
+        assert not (codex_home / "skills").exists()
         assert not (project_root / ".codex").exists()
-        assert not any((codex_home / "skills").iterdir())
+        assert (project_root / ".agents" / "skills").is_dir()
+        assert not any((project_root / ".agents" / "skills").iterdir())
 
     def test_detects_marker_in_agent_message(self, tmp_path):
         """Verify marker detection in codex JSONL output."""
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         with patch("scripts.run_eval_codex.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value.hex = "abcd1234xxxxxxxxxxxxxxxx"
@@ -460,7 +461,7 @@ class TestRunSingleQueryCodex:
     def test_no_trigger_returns_false(self, tmp_path):
         """No marker in output means not triggered."""
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         events = [
             json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "No skill here."}}),
@@ -621,12 +622,12 @@ class TestRunEval:
 class TestTemporarySkillNames:
     def test_codex_temp_skill_keeps_original_visible_name(self, tmp_path):
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         observed = {}
 
         def capture_popen(cmd, **kwargs):
-            skill_root = project_root / ".codex" / "skills"
+            skill_root = project_root / ".agents" / "skills"
             skill_file = next(skill_root.glob("*/SKILL.md"))
             observed["path"] = skill_file
             observed["content"] = skill_file.read_text()
@@ -679,14 +680,14 @@ class TestTemporarySkillNames:
 
     def test_codex_temp_skill_paths_are_isolated_per_run(self, tmp_path):
         project_root = tmp_path / "project"
-        (project_root / ".codex" / "skills").mkdir(parents=True)
+        (project_root / ".agents" / "skills").mkdir(parents=True)
 
         observed_snapshots = []
         observed_lock = threading.Lock()
         barrier = threading.Barrier(2)
 
         def capture_popen(cmd, **kwargs):
-            skill_root = project_root / ".codex" / "skills"
+            skill_root = project_root / ".agents" / "skills"
             barrier.wait(timeout=2)
             snapshot = sorted(path.name for path in skill_root.iterdir())
             with observed_lock:

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
@@ -269,7 +269,7 @@ class TestRunSingleQueryClaude:
 
         assert result is True
 
-    def test_uses_isolated_workspace_for_temp_command_even_with_override(self, tmp_path):
+    def test_uses_isolated_workspace_for_temp_skill_even_with_override(self, tmp_path):
         project_root = tmp_path / "project"
         project_root.mkdir()
         claude_home = tmp_path / "custom-claude-home"
@@ -284,6 +284,7 @@ class TestRunSingleQueryClaude:
             def capture_popen(*args, **kwargs):
                 observed["cwd"] = Path(kwargs["cwd"])
                 observed["claude_home"] = Path(kwargs["env"]["SKILL_FORGE_CLAUDE_HOME"])
+                observed["claude_config_dir"] = Path(kwargs["env"]["CLAUDE_CONFIG_DIR"])
                 return mock_process
 
             with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
@@ -296,43 +297,50 @@ class TestRunSingleQueryClaude:
         assert result is False
         assert observed["cwd"] == project_root
         assert observed["claude_home"].parent == project_root
+        assert observed["claude_config_dir"] == observed["claude_home"]
         assert not observed["claude_home"].exists()
         assert not (claude_home / "commands").exists()
+        assert not (claude_home / "skills").exists()
         assert not (project_root / ".claude").exists()
 
-    def test_detects_skill_path_from_override_claude_home(self, tmp_path):
+    def test_copies_supporting_files_into_temp_skill(self, tmp_path):
         project_root = tmp_path / "project"
-        project_root.mkdir()
-        claude_home = tmp_path / "custom-claude-home"
+        source_skill = project_root / ".claude" / "skills" / SKILL_NAME
+        source_skill.mkdir(parents=True)
+        (source_skill / "SKILL.md").write_text(
+            "---\n"
+            f"name: {SKILL_NAME}\n"
+            "description: old desc\n"
+            "---\n\n"
+            "# Old\n"
+        )
+        (source_skill / "references").mkdir()
+        (source_skill / "references" / "guide.md").write_text("supporting file")
+
+        observed = {}
 
         events = [
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "content": [
-                        {
-                            "type": "tool_use",
-                            "name": "Read",
-                            "input": {
-                                "file_path": str(claude_home / "skills" / SKILL_NAME / "SKILL.md"),
-                            },
-                        },
-                    ],
-                },
-            }),
             json.dumps({"type": "result"}),
         ]
         mock_process, output = self._make_process_mock(events)
 
-        with patch.dict(os.environ, {"SKILL_FORGE_CLAUDE_HOME": str(claude_home)}, clear=True):
-            with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-                with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                    with patch("scripts.run_eval_claude.os.read", return_value=output):
-                        result = run_single_query_claude(
-                            "test query", SKILL_NAME, "test desc", 5, str(project_root),
-                        )
+        def capture_popen(*args, **kwargs):
+            temp_skill = Path(kwargs["env"]["SKILL_FORGE_CLAUDE_HOME"]) / "skills" / SKILL_NAME
+            observed["skill_md"] = (temp_skill / "SKILL.md").read_text()
+            observed["supporting_file"] = (temp_skill / "references" / "guide.md").read_text()
+            return mock_process
 
-        assert result is True
+        with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
+            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.run_eval_claude.os.read", return_value=output):
+                    result = run_single_query_claude(
+                        "test query", SKILL_NAME, "test desc", 5, str(project_root),
+                    )
+
+        assert result is False
+        assert "description: |\n  test desc\n" in observed["skill_md"]
+        assert "old desc" not in observed["skill_md"]
+        assert observed["supporting_file"] == "supporting file"
 
     def test_detects_relative_skill_path_from_read_tool_use(self, tmp_path):
         project_root = tmp_path / "project"
@@ -650,17 +658,17 @@ class TestTemporarySkillNames:
         assert "name: skill-forge\n" in observed["content"]
         assert f"name: {SKILL_NAME}-skill-" not in observed["content"]
 
-    def test_claude_temp_command_keeps_original_visible_name(self, tmp_path):
+    def test_claude_temp_skill_keeps_original_visible_name(self, tmp_path):
         project_root = tmp_path / "project"
         project_root.mkdir()
 
         observed = {}
 
         def capture_popen(cmd, **kwargs):
-            command_root = Path(kwargs["env"]["SKILL_FORGE_CLAUDE_HOME"]) / "commands"
-            command_file = next(command_root.glob("*.md"))
-            observed["path"] = command_file
-            observed["content"] = command_file.read_text()
+            skill_root = Path(kwargs["env"]["SKILL_FORGE_CLAUDE_HOME"]) / "skills"
+            skill_file = next(skill_root.glob("*/SKILL.md"))
+            observed["path"] = skill_file
+            observed["content"] = skill_file.read_text()
 
             mock_process = MagicMock()
             mock_process.poll.side_effect = [0, 0]
@@ -675,7 +683,9 @@ class TestTemporarySkillNames:
                     "test query", SKILL_NAME, "test desc", 5, str(project_root),
                 )
 
-        assert observed["path"].name == f"{SKILL_NAME}.md"
+        assert observed["path"].parent.name == SKILL_NAME
+        assert observed["path"].name == "SKILL.md"
+        assert f"name: {SKILL_NAME}\n" in observed["content"]
         assert f"# {SKILL_NAME}\n" in observed["content"]
 
     def test_codex_temp_skill_paths_are_isolated_per_run(self, tmp_path):
@@ -722,7 +732,7 @@ class TestTemporarySkillNames:
         assert all(len(snapshot) == 2 for snapshot in observed_snapshots)
         assert all(len(set(snapshot)) == 2 for snapshot in observed_snapshots)
 
-    def test_claude_temp_command_paths_are_isolated_per_run(self, tmp_path):
+    def test_claude_temp_skill_paths_are_isolated_per_run(self, tmp_path):
         project_root = tmp_path / "project"
         project_root.mkdir()
 
@@ -732,9 +742,9 @@ class TestTemporarySkillNames:
 
         def capture_popen(cmd, **kwargs):
             claude_home = Path(kwargs["env"]["SKILL_FORGE_CLAUDE_HOME"])
-            command_root = claude_home / "commands"
+            skill_root = claude_home / "skills"
             barrier.wait(timeout=2)
-            snapshot = sorted(path.name for path in command_root.glob("*.md"))
+            snapshot = sorted(path.name for path in skill_root.iterdir())
             with observed_lock:
                 observed_paths.append((claude_home.name, snapshot))
 
@@ -764,7 +774,7 @@ class TestTemporarySkillNames:
 
         assert len(observed_paths) == 2
         assert len({path for path, _ in observed_paths}) == 2
-        assert all(snapshot == [f"{SKILL_NAME}.md"] for _, snapshot in observed_paths)
+        assert all(snapshot == [SKILL_NAME] for _, snapshot in observed_paths)
 
     def test_claude_runs_in_project_root_with_isolated_home(self, tmp_path):
         project_root = tmp_path / "project"

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
@@ -203,6 +203,72 @@ class TestRunSingleQueryClaude:
 
         assert result is True
 
+    def test_detects_stream_event_skill_tool_use(self, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        events = [
+            json.dumps({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_start",
+                    "content_block": {"type": "tool_use", "name": "Skill"},
+                },
+            }),
+            json.dumps({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": json.dumps({"skill": SKILL_NAME}),
+                    },
+                },
+            }),
+            json.dumps({
+                "type": "stream_event",
+                "event": {"type": "content_block_stop"},
+            }),
+        ]
+        mock_process, output = self._make_process_mock(events)
+
+        with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
+            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.run_eval_claude.os.read", return_value=output):
+                    result = run_single_query_claude(
+                        "test query", SKILL_NAME, "test desc", 5, str(project_root),
+                    )
+
+        assert result is True
+
+    def test_stream_event_shape_change_does_not_trigger(self, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        events = [
+            json.dumps({
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {
+                        "type": "text_delta",
+                        "text": json.dumps({"skill": SKILL_NAME}),
+                    },
+                },
+            }),
+            json.dumps({"type": "result"}),
+        ]
+        mock_process, output = self._make_process_mock(events)
+
+        with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
+            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.run_eval_claude.os.read", return_value=output):
+                    result = run_single_query_claude(
+                        "test query", SKILL_NAME, "test desc", 5, str(project_root),
+                    )
+
+        assert result is False
+
     def test_ignores_non_matching_tool_before_skill_trigger(self, tmp_path):
         project_root = tmp_path / "project"
         project_root.mkdir()
@@ -466,6 +532,68 @@ class TestRunSingleQueryCodex:
 
             assert result is True
 
+    def test_detects_marker_in_updated_agent_message(self, tmp_path):
+        project_root = tmp_path / "project"
+        (project_root / ".agents" / "skills").mkdir(parents=True)
+
+        with patch("scripts.run_eval_codex.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "abcd1234xxxxxxxxxxxxxxxx"
+            marker = "[SKILL_TRIGGERED:abcd1234]"
+
+            events = [
+                json.dumps({"type": "item.updated", "item": {"type": "agent_message", "text": f"{marker}"}}),
+            ]
+            output = ("\n".join(events) + "\n").encode()
+
+            mock_process = MagicMock()
+            mock_process.poll.side_effect = [None, 0]
+            mock_process.stdout.fileno.return_value = 0
+            mock_process.stdout.read.return_value = output
+            mock_process.stderr.read.return_value = b""
+            mock_process.returncode = 0
+
+            with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
+                with patch("scripts.run_eval_codex.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.run_eval_codex.os.read", return_value=output):
+                        result = run_single_query_codex(
+                            "test query", "my-skill", "test desc", 5, str(project_root),
+                        )
+
+            assert result is True
+
+    def test_codex_event_shape_change_does_not_trigger(self, tmp_path):
+        project_root = tmp_path / "project"
+        (project_root / ".agents" / "skills").mkdir(parents=True)
+
+        with patch("scripts.run_eval_codex.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "abcd1234xxxxxxxxxxxxxxxx"
+            marker = "[SKILL_TRIGGERED:abcd1234]"
+
+            events = [
+                json.dumps({
+                    "type": "message.completed",
+                    "message": {"role": "assistant", "content": f"{marker}"},
+                }),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+            output = ("\n".join(events) + "\n").encode()
+
+            mock_process = MagicMock()
+            mock_process.poll.side_effect = [None, 0]
+            mock_process.stdout.fileno.return_value = 0
+            mock_process.stdout.read.return_value = output
+            mock_process.stderr.read.return_value = b""
+            mock_process.returncode = 0
+
+            with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
+                with patch("scripts.run_eval_codex.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.run_eval_codex.os.read", return_value=output):
+                        result = run_single_query_codex(
+                            "test query", "my-skill", "test desc", 5, str(project_root),
+                        )
+
+            assert result is False
+
     def test_no_trigger_returns_false(self, tmp_path):
         """No marker in output means not triggered."""
         project_root = tmp_path / "project"
@@ -523,6 +651,8 @@ class TestRunEval:
         assert result["summary"]["total"] == 2
         assert result["summary"]["passed"] == 2
         assert result["summary"]["failed"] == 0
+        assert {r["status"] for r in result["results"]} == {"ok"}
+        assert {r["attempted_runs"] for r in result["results"]} == {1}
 
     def test_eval_with_failures(self):
         eval_set = [
@@ -623,8 +753,33 @@ class TestRunEval:
         assert result["summary"]["failed"] == 1
         assert result["summary"]["errors"] == 1
         assert result["results"][0]["runs"] == 0
+        assert result["results"][0]["attempted_runs"] == 1
+        assert result["results"][0]["status"] == "error"
         assert result["results"][0]["pass"] is False
         assert result["results"][0]["error_count"] == 1
+
+    def test_query_with_zero_attempted_runs_is_marked_not_run(self):
+        eval_set = [{"query": "do not trigger", "should_trigger": False}]
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
+            result = run_eval(
+                eval_set=eval_set,
+                skill_name="test",
+                description="desc",
+                num_workers=1,
+                timeout=10,
+                project_root=Path("/tmp"),
+                runs_per_query=0,
+                trigger_threshold=0.5,
+                cli_type=CLI_CLAUDE,
+            )
+
+        assert result["summary"]["total"] == 1
+        assert result["summary"]["failed"] == 1
+        assert result["results"][0]["runs"] == 0
+        assert result["results"][0]["attempted_runs"] == 0
+        assert result["results"][0]["status"] == "not_run"
+        assert result["results"][0]["pass"] is False
 
 
 class TestTemporarySkillNames:

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
@@ -56,6 +56,16 @@ class TestSkillDocs:
         assert "status" in schemas
         assert "attempted_runs" in schemas
 
+    def test_eval_schema_terms_are_consistent(self):
+        skill_md = (SKILL_DIR / "SKILL.md").read_text()
+        schemas = (SKILL_DIR / "references" / "schemas.md").read_text()
+
+        assert '"expectations": []' in skill_md
+        assert "## eval_metadata.json" in schemas
+        assert "`expectations` as the canonical field" in schemas
+        assert "legacy alias" in schemas
+        assert "writers must emit `expectations`" in schemas
+
 
 class TestProjectMetadata:
     def test_pyproject_does_not_depend_on_anthropic(self):

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
@@ -31,6 +31,18 @@ class TestSkillDocs:
         assert "improvement step always uses the Anthropic API directly" not in skill_md
         assert "No separate Anthropic API client setup is required" in skill_md
 
+    def test_codex_openai_yaml_flow_is_documented(self):
+        skill_md = (SKILL_DIR / "SKILL.md").read_text()
+        reference = (SKILL_DIR / "references" / "openai_yaml.md").read_text()
+
+        assert "references/openai_yaml.md" in skill_md
+        assert "scripts/generate_openai_yaml.py" in skill_md
+        assert "--strict-openai-yaml" in skill_md
+        assert "display_name" in reference
+        assert "short_description" in reference
+        assert "default_prompt" in reference
+        assert "Difference from OpenAI skill-creator" in reference
+
 
 class TestProjectMetadata:
     def test_pyproject_does_not_depend_on_anthropic(self):

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
@@ -21,7 +21,24 @@ class TestSkillDocs:
         assert "references/eval_workflow.md" in skill_md
         assert "references/description_optimization.md" in skill_md
         assert "references/platform_notes.md" in skill_md
+        assert "references/skill_creator_comparison.md" in skill_md
         assert "Read only the reference files needed for the current branch" in skill_md
+
+    def test_skill_creator_comparison_reference_covers_platform_differences(self):
+        skill_md = (SKILL_DIR / "SKILL.md").read_text()
+        reference = (SKILL_DIR / "references" / "skill_creator_comparison.md").read_text()
+
+        assert "references/skill_creator_comparison.md" in skill_md
+        assert "Creation flow comparison" in reference
+        assert "Evaluation flow comparison" in reference
+        assert "Distribution flow comparison" in reference
+        assert "OpenAI skill-creator differences" in reference
+        assert "Anthropic-derived functionality" in reference
+        assert "skill-forge-specific extensions" in reference
+        assert "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md" in reference
+        assert "https://github.com/openai/skills/blob/main/skills/.system/skill-creator/SKILL.md" in reference
+        assert "https://developers.openai.com/codex/skills" in reference
+        assert "https://docs.anthropic.com/en/docs/claude-code/skills" in reference
 
     def test_frontmatter_description_mentions_existing_skill_and_boundary(self):
         _, description, _ = parse_skill_md(SKILL_DIR)

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
@@ -43,6 +43,19 @@ class TestSkillDocs:
         assert "default_prompt" in reference
         assert "Difference from OpenAI skill-creator" in reference
 
+    def test_trigger_eval_boundaries_are_documented(self):
+        skill_md = (SKILL_DIR / "SKILL.md").read_text()
+        reference = (SKILL_DIR / "references" / "trigger_eval_boundaries.md").read_text()
+        schemas = (SKILL_DIR / "references" / "schemas.md").read_text()
+
+        assert "references/trigger_eval_boundaries.md" in skill_md
+        assert "Claude Code detector" in reference
+        assert "Codex CLI detector" in reference
+        assert "false positives" in reference
+        assert "false negatives" in reference
+        assert "status" in schemas
+        assert "attempted_runs" in schemas
+
 
 class TestProjectMetadata:
     def test_pyproject_does_not_depend_on_anthropic(self):

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
@@ -9,6 +9,20 @@ SKILL_DIR = Path(__file__).parent.parent
 
 
 class TestSkillDocs:
+    def test_skill_md_stays_under_progressive_disclosure_line_budget(self):
+        skill_md = (SKILL_DIR / "SKILL.md").read_text()
+
+        assert len(skill_md.splitlines()) < 500
+
+    def test_split_references_are_discoverable_from_skill_md(self):
+        skill_md = (SKILL_DIR / "SKILL.md").read_text()
+
+        assert "references/skill_authoring.md" in skill_md
+        assert "references/eval_workflow.md" in skill_md
+        assert "references/description_optimization.md" in skill_md
+        assert "references/platform_notes.md" in skill_md
+        assert "Read only the reference files needed for the current branch" in skill_md
+
     def test_frontmatter_description_mentions_existing_skill_and_boundary(self):
         _, description, _ = parse_skill_md(SKILL_DIR)
 

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_md.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_md.py
@@ -55,16 +55,13 @@ def project_root():
     """開発環境を汚染しないよう /tmp 以下に隔離された作業ディレクトリを作成する。
 
     claude が動作するために必要な構造:
-      .claude/commands/              ← run_single_query_claude が一時コマンドファイルを置く場所
-      .claude/skills/<skill-name>/   ← claude が SKILL.md 本体を読みに来る場所
+      .claude/skills/<skill-name>/   ← run_single_query_claude が一時 skill home にコピーする元
     """
     tmp_dir = tempfile.mkdtemp(prefix="skill-forge-test-")
     tmp_path = Path(tmp_dir)
 
     # claude -p requires a git repository to function correctly
     subprocess.run(["git", "init", "-q"], cwd=tmp_dir, check=True)
-
-    (tmp_path / ".claude" / "commands").mkdir(parents=True)
 
     _IGNORE = shutil.ignore_patterns(".venv", "__pycache__", ".pytest_cache", "*.pyc")
     skill_name, _, _ = parse_skill_md(SKILL_DIR)

--- a/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
@@ -195,11 +195,24 @@ class TestResolveCliHome:
             result = resolve_cli_home(CLI_CODEX, project)
             assert result == override
 
-    def test_resolve_skill_dir_uses_cli_home(self, tmp_path):
+    def test_claude_resolve_skill_dir_uses_cli_home(self, tmp_path):
+        override = tmp_path / "custom-claude-home"
+        with patch.dict(os.environ, {"SKILL_FORGE_CLAUDE_HOME": str(override)}, clear=True):
+            result = resolve_skill_dir(CLI_CLAUDE, tmp_path / "project")
+            assert result == override / "skills"
+
+    def test_codex_resolve_skill_dir_uses_repo_agents_skills(self, tmp_path):
+        project = tmp_path / "project"
+        with patch.dict(os.environ, {}, clear=True):
+            result = resolve_skill_dir(CLI_CODEX, project)
+            assert result == project / ".agents" / "skills"
+
+    def test_codex_resolve_skill_dir_ignores_codex_home_for_repo_scope(self, tmp_path):
+        project = tmp_path / "project"
         override = tmp_path / "custom-codex-home"
         with patch.dict(os.environ, {"CODEX_HOME": str(override)}, clear=True):
-            result = resolve_skill_dir(CLI_CODEX, tmp_path / "project")
-            assert result == override / "skills"
+            result = resolve_skill_dir(CLI_CODEX, project)
+            assert result == project / ".agents" / "skills"
 
     def test_utils_module_does_not_expose_resolve_command_dir(self):
         assert not hasattr(utils_module, "resolve_command_dir")


### PR DESCRIPTION
## Summary

- Align skill-forge trigger evaluation paths with current Claude Code and Codex skill discovery behavior.
- Add platform-aware validation for Claude/Codex frontmatter and Codex `agents/openai.yaml` metadata.
- Generate and strictly validate Codex metadata, including stale `SKILL.md` source-hash detection.
- Normalize eval schema terminology to canonical `expectations` while preserving legacy `assertions` read compatibility.
- Split `SKILL.md` into progressive-disclosure references and add a permanent Anthropic/OpenAI skill-creator comparison reference.

## Issues

Closes #51
Closes #52
Closes #53
Closes #54
Closes #55
Closes #56
Closes #57
Closes #58

Parent: #50

## Validation

- `uv run pytest -q -m "not integration"` -> 105 passed, 16 deselected
- `uv run python scripts/quick_validate.py . && uv run python scripts/quick_validate.py . --platform codex --strict-openai-yaml` -> pass
- `bash scripts/ci/verify.sh` -> pass
- `git diff --check` -> pass

## Notes

The PR intentionally keeps the heavy Anthropic-derived eval loop while making Codex-specific discovery, metadata, and validation explicit. The new comparison reference records where skill-forge follows Anthropic, where it follows OpenAI, and where it deliberately diverges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large doc and workflow refactor plus trigger-eval path changes; incorrect discovery or detector parsing could mislead skill authors, though unit tests and CI validation were expanded.
> 
> **Overview**
> Aligns **skill-forge** with current Claude Code and Codex skill behavior: slimmer `SKILL.md` with a progressive-disclosure map into new `references/*` guides (authoring, eval workflow, Codex `openai.yaml`, trigger-eval limits, platform notes, Anthropic/OpenAI creator comparison).
> 
> **Trigger evals & discovery:** Codex trigger tests use repo **`.agents/skills`** (not `.codex/skills`); Claude tests use isolated temp **`skills/<name>/SKILL.md`** homes instead of command shims, with `CLAUDE_CONFIG_DIR` set. `run_eval` adds **`status`**, **`attempted_runs`**, and clearer infra vs non-trigger semantics; docs cover detector false positives/negatives.
> 
> **Codex metadata:** New **`scripts/generate_openai_yaml.py`** and **`agents/openai.yaml`** for skill-forge; **`quick_validate.py`** gains **`--platform claude|codex|auto`** and **`--strict-openai-yaml`** (required UI fields + **SKILL.md SHA256** stale check). CI runs strict Codex validation.
> 
> **Eval schema:** Canonical graded checks are **`expectations`** (legacy **`assertions`** still read in grader, viewer, aggregator, schemas, and agent docs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299baf85bf14ead656db3c937cf6a49c8c848f86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->