### PR TITLE
TAKTレビュー用ワークフローの集約条件を修正

### DIFF
--- a/plugins/takt/skills/takt-analyzer/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/plugins/takt/skills/takt-analyzer/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋並列レビュー、監督者指摘の再修正）
+description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋6並列レビュー、監督者指摘の再修正）
 workflow_config:
   provider_options:
     codex:

--- a/plugins/takt/skills/takt-analyzer/references/takt/builtins/ja/workflows/terraform.yaml
+++ b/plugins/takt/skills/takt-analyzer/references/takt/builtins/ja/workflows/terraform.yaml
@@ -178,9 +178,9 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
-      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved")
+      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved", "approved")
         next: supervise
-      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")
+      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix", "needs_fix")
         next: supervise
   - name: supervise
     tags:

--- a/plugins/takt/skills/takt-facet-builder/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/plugins/takt/skills/takt-facet-builder/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋並列レビュー、監督者指摘の再修正）
+description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋6並列レビュー、監督者指摘の再修正）
 workflow_config:
   provider_options:
     codex:

--- a/plugins/takt/skills/takt-facet-builder/references/takt/builtins/ja/workflows/terraform.yaml
+++ b/plugins/takt/skills/takt-facet-builder/references/takt/builtins/ja/workflows/terraform.yaml
@@ -178,9 +178,9 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
-      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved")
+      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved", "approved")
         next: supervise
-      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")
+      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix", "needs_fix")
         next: supervise
   - name: supervise
     tags:

--- a/plugins/takt/skills/takt-optimizer/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/plugins/takt/skills/takt-optimizer/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋並列レビュー、監督者指摘の再修正）
+description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋6並列レビュー、監督者指摘の再修正）
 workflow_config:
   provider_options:
     codex:

--- a/plugins/takt/skills/takt-optimizer/references/takt/builtins/ja/workflows/terraform.yaml
+++ b/plugins/takt/skills/takt-optimizer/references/takt/builtins/ja/workflows/terraform.yaml
@@ -178,9 +178,9 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
-      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved")
+      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved", "approved")
         next: supervise
-      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")
+      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix", "needs_fix")
         next: supervise
   - name: supervise
     tags:

--- a/plugins/takt/skills/takt-skill-updater/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/plugins/takt/skills/takt-skill-updater/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋並列レビュー、監督者指摘の再修正）
+description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋6並列レビュー、監督者指摘の再修正）
 workflow_config:
   provider_options:
     codex:

--- a/plugins/takt/skills/takt-skill-updater/references/takt/builtins/ja/workflows/terraform.yaml
+++ b/plugins/takt/skills/takt-skill-updater/references/takt/builtins/ja/workflows/terraform.yaml
@@ -178,9 +178,9 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
-      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved")
+      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved", "approved")
         next: supervise
-      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")
+      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix", "needs_fix")
         next: supervise
   - name: supervise
     tags:

--- a/plugins/takt/skills/takt-workflow-builder/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/plugins/takt/skills/takt-workflow-builder/references/takt/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋並列レビュー、監督者指摘の再修正）
+description: TAKT開発向け多角レビュー＋修正ループ（初回7並列レビュー（コーディングレビュー含む）、修正後はAIアンチパターン事前レビュー＋6並列レビュー、監督者指摘の再修正）
 workflow_config:
   provider_options:
     codex:

--- a/plugins/takt/skills/takt-workflow-builder/references/takt/builtins/ja/workflows/terraform.yaml
+++ b/plugins/takt/skills/takt-workflow-builder/references/takt/builtins/ja/workflows/terraform.yaml
@@ -178,9 +178,9 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
-      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved")
+      - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved", "approved")
         next: supervise
-      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")
+      - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix", "needs_fix")
         next: supervise
   - name: supervise
     tags:


### PR DESCRIPTION
## 概要

TAKT関連スキルに含まれるレビュー用ワークフローの不整合を修正します。

## 変更内容

- `review-fix-takt-default.yaml` の説明文を実際の修正後レビュー構成に合わせて `AIアンチパターン事前レビュー＋6並列レビュー` に修正
- `terraform.yaml` の `reviewers` 並列ステップが4本になっていることに合わせて、集約条件の `all()` / `any()` を4引数に修正
- 同一構成を持つ5つのTAKTスキル配下へ同じ修正を適用

## 背景

既存レビューコメントで、`pure-review` 追加後も Terraform レビューの集約条件が3引数のままで、後続レビュー結果が判定から漏れる可能性が指摘されていました。また、レビュー修正ループの説明文も実際の並列数と一致していませんでした。

## 検証

- 変更したYAML 10ファイルを `YAML.load_file` でロードできることを確認
- 5つの `terraform.yaml` で `reviewers.parallel` の数と `all()` / `any()` の引数数が一致することを確認
- 古い条件・説明文が残っていないことを `rg` で確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> ワークフロー分岐条件の修正のため、誤るとレビュー結果の取りこぼしや遷移の変化があり得ますが、並列数との整合を取る意図の限定的な変更です。
> 
> **Overview**
> **TAKT組み込みレビューワークフロー**の説明と並列レビュー後の分岐条件を、実際のステップ構成に揃える変更です。5つのTAKTスキル配下の同一YAML参照に同内容を反映しています。
> 
> `review-fix-takt-default.yaml` の `description` を、修正後ループが **AIアンチパターン事前レビュー＋6並列レビュー** である旨に更新しました（従来は並列数が曖昧な表現でした）。
> 
> `terraform.yaml` の `reviewers` ステップでは、`pure-review` 追加後も **4本の `parallel` レビュー**に対して親の `rules` が **3引数の `all()` / `any()`** のままだったため、`coding-review` 側の `approved` / `needs_fix` を集約条件に含めるよう **4引数**に拡張しました。これにより、並列レビュー結果が監督ステップへ進む前の判定から漏れにくくなります。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ec6dab8c00ad32f16c0687f55b6353ba69fbd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->