### PR TITLE
[codex] Require defaultPrompt array in Codex plugin manifests

### DIFF
--- a/scripts/validate-codex-plugin-manifests.py
+++ b/scripts/validate-codex-plugin-manifests.py
@@ -125,14 +125,11 @@ def validate_interface(interface: dict[str, Any], label: str, failures: list[str
             continue
         require_non_empty_string(interface, field, f"{label}.interface", failures)
 
-    default_prompt = interface.get("defaultPrompt") or interface.get("default_prompt")
-    if not default_prompt:
-        failures.append(f"{label}: interface.defaultPrompt is required")
-    elif isinstance(default_prompt, list):
-        if not all(isinstance(value, str) and value.strip() for value in default_prompt):
-            failures.append(f"{label}: interface.defaultPrompt entries must be non-empty strings")
-    elif not isinstance(default_prompt, str):
-        failures.append(f"{label}: interface.defaultPrompt must be a string or string list")
+    default_prompt = interface.get("defaultPrompt")
+    if not isinstance(default_prompt, list) or not default_prompt or not all(
+        isinstance(value, str) and value.strip() for value in default_prompt
+    ):
+        failures.append(f"{label}: interface.defaultPrompt must be a non-empty string list")
 
 
 def require_non_empty_string(


### PR DESCRIPTION
## Summary

- Require Codex plugin `interface.defaultPrompt` to be a non-empty string array.
- Remove the previous single-string fallback so invalid plugin manifests fail validation.
- Aligns with the review feedback from PR #63: https://github.com/j5ik2o/ai-tools/pull/63#discussion_r3503023747

## Validation

- `npm run validate:codex-plugins`
- Direct negative/positive check via `validate_interface`: rejects string, empty array, empty-string entry, and `default_prompt`; accepts non-empty `defaultPrompt` string array
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change in a dev script; in-repo manifests already use `defaultPrompt` arrays, so CI impact is limited to stricter rejection of invalid manifests.
> 
> **Overview**
> Tightens **Codex plugin manifest** validation in `validate_interface` so `interface.defaultPrompt` must be a **non-empty array of non-empty strings**, matching how existing plugins (e.g. `git`, `github`) already declare prompts.
> 
> **Removed** acceptance of a single string, empty arrays, blank entries, and the snake_case `default_prompt` alias—those shapes now fail with one consolidated error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10348dd19baae77aaeab7eaa5db3d20e792496b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->