### PR TITLE
skill-forge に大規模リファクタ時の知識保持ルールを追加

### DIFF
--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -39,8 +39,10 @@ If the user already has a draft, start at validation, evals, or iteration.
 
 Read only the reference files needed for the current branch:
 
-- `references/skill_authoring.md` - read before drafting or reviewing a
-  `SKILL.md`, especially when the body may approach 500 lines.
+- `references/skill_authoring.md` - read before drafting, reviewing, or large
+  refactoring a `SKILL.md`, especially when the body may approach 500 lines or
+  existing skill knowledge is being shortened, reorganized, translated, or moved
+  into references.
 - `references/eval_workflow.md` - read before running test cases, benchmarks,
   grading, viewer generation, blind comparison, or iteration from feedback.
 - `references/description_optimization.md` - read before optimizing or debugging
@@ -167,6 +169,10 @@ For schema details, read `references/schemas.md`. Writers must emit
 
 Improve from evidence, not from vibes alone:
 
+- For large refactors of existing skills, run the preservation pass in
+  `references/skill_authoring.md` before editing and before final validation.
+  Do not treat "shorten", "organize", "Englishize", or "move to references" as
+  permission to discard behavior-shaping skill knowledge.
 - Generalize from user feedback instead of overfitting to one eval prompt.
 - Read transcripts when outputs are surprising.
 - Remove instructions that cause repeated wasted work.

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: afb86a5c30ad7a3be02f4d2d488bd44194bd06a7023fee83b7303b3fec9640bb
+# skill-forge-source-sha256: c19979d30a89ff5b69d7a857424eee7c4216ebb74c82040f89b48afd8b5644f1
 interface:
   display_name: "Skill Forge"
   short_description: "Create and improve agent skills"

--- a/plugins/agent-skills/skills/skill-forge/references/skill_authoring.md
+++ b/plugins/agent-skills/skills/skill-forge/references/skill_authoring.md
@@ -51,6 +51,76 @@ cloud-deploy/
 
 The agent should read only the relevant reference file.
 
+## Large refactors of existing skills
+
+Run a preservation pass when changing the information structure of an existing
+skill. This includes shortening a long `SKILL.md`, translating a skill,
+reorganizing sections, splitting content into `references/`, or updating many
+skills in one batch.
+
+The top invariant is: do not discard behavior-shaping knowledge. Shortening a
+`SKILL.md` should usually reduce the loaded entrypoint, not reduce what the skill
+knows how to do.
+
+Do not treat requests like "shorten", "organize", "Englishize", or "move to
+references" as permission to discard preserved knowledge. Discarding preserved
+knowledge requires explicit user approval.
+
+### Preserved knowledge categories
+
+Track these categories before editing and again before final validation:
+
+1. Trigger boundary: when to use the skill, when not to use it, and boundaries
+   with nearby skills or ordinary workflow.
+2. Decision criteria: judgment rules, priorities, tradeoffs, and branch
+   conditions.
+3. Failure modes: anti-patterns, misuse cases, false positives, and things the
+   skill must avoid.
+4. Procedure: ordered steps, completion criteria, required tools, and handoff
+   points.
+5. Examples: input/output examples, code examples, classification examples, and
+   representative edge cases.
+6. Verification: eval intent, validation commands, review checks, and expected
+   artifacts.
+
+If one of these categories is removed from `SKILL.md`, preserve equivalent
+content in `references/*.md` or record the user's explicit approval to reduce
+the information.
+
+### Reference link contract
+
+Every new or expanded reference file created during a refactor must be linked
+from `SKILL.md`. The link must say when to read the file; a bare "see details"
+is not enough.
+
+Good:
+
+```markdown
+Read `references/details.md` before non-trivial implementation, review,
+refactoring, or migration work. It contains decision criteria, failure modes,
+examples, and verification notes preserved from the original skill.
+```
+
+Before finishing, check that every referenced file exists and every new
+`references/*.md` file has a discoverable pointer from `SKILL.md`.
+
+### Preservation checklist
+
+Maintain this checklist while editing large refactors, then summarize it in the
+final report:
+
+- Trigger boundary preserved or intentionally changed.
+- Decision criteria preserved or moved.
+- Failure modes preserved or moved.
+- Procedure and completion criteria preserved or moved.
+- Examples preserved, moved, or intentionally reduced with user approval.
+- Verification and eval intent preserved.
+- Every new reference file is linked from `SKILL.md` with a read condition.
+
+`quick_validate.py` is not enough for this branch. It checks syntax and platform
+metadata, not whether a refactor changed the skill's behavior. Run quick
+validation after the preservation review, not instead of it.
+
 ## Principle of lack of surprise
 
 Skills must not contain malware, exploit code, hidden data exfiltration, or any


### PR DESCRIPTION
## 概要

skill-forge に、既存スキルの大規模リファクタリング時に挙動へ効く知識を削らないための preservation pass を追加しました。

## 変更内容

- `SKILL.md` の progressive disclosure map に large refactor 時の `skill_authoring.md` 参照条件を追加
- `Improving a skill` に、短縮・整理・英語化・references 移動を情報削除許可とみなさないルールを追加
- `references/skill_authoring.md` に以下を追加
  - preserved knowledge 6カテゴリ
  - references 切り出し時のリンク保証
  - preservation checklist
  - `quick_validate.py` だけでは不十分という注意

## 検証

- `uv run python scripts/quick_validate.py . --platform codex`
- `uv run pytest tests/test_skill_docs.py --override-ini addopts=''`
- `git diff --check`
- 対象2ファイルの日本語残存チェック

## 補足

`uv run pytest tests/test_skill_md.py tests/test_skill_docs.py` は `test_skill_docs.py` は通過しましたが、`test_skill_md.py::test_skill_trigger` の既存の確率的 trigger eval で、未変更の frontmatter description に対する発火率が 1/3 となり1件失敗しました。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to skill-forge guidance and Codex metadata hash; no application runtime or security logic is modified.
> 
> **Overview**
> Adds a **preservation pass** workflow so skill-forge agents do not lose behavior-shaping knowledge when refactoring existing skills (shortening, reorganizing, translating, or moving content into `references/`).
> 
> `SKILL.md` now points readers to `references/skill_authoring.md` for large refactors and states in **Improving a skill** that cleanup-style requests are not implicit permission to delete preserved knowledge. The authoring reference defines six preserved-knowledge categories, a reference-link contract (when-to-read links from `SKILL.md`), a preservation checklist for final reports, and clarifies that `quick_validate.py` cannot substitute for behavioral preservation review.
> 
> `agents/openai.yaml` source SHA is updated to match the changed `SKILL.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9faf42295de5121b530ee3bacbe36519d14d96e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->