### PR TITLE
fix(skill-forge): isolate trigger evals from installed skills and surface timeouts

### DIFF
--- a/plugins/agent-skills/skills/skill-forge/eval-viewer/generate_review.py
+++ b/plugins/agent-skills/skills/skill-forge/eval-viewer/generate_review.py
@@ -16,12 +16,8 @@ import argparse
 import base64
 import json
 import mimetypes
-import os
 import re
-import signal
-import subprocess
 import sys
-import time
 import webbrowser
 from functools import partial
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -287,26 +283,6 @@ def generate_html(
 # HTTP server (stdlib only, zero dependencies)
 # ---------------------------------------------------------------------------
 
-def _kill_port(port: int) -> None:
-    """Kill any process listening on the given port."""
-    try:
-        result = subprocess.run(
-            ["lsof", "-ti", f":{port}"],
-            capture_output=True, text=True, timeout=5,
-        )
-        for pid_str in result.stdout.strip().split("\n"):
-            if pid_str.strip():
-                try:
-                    os.kill(int(pid_str.strip()), signal.SIGTERM)
-                except (ProcessLookupError, ValueError):
-                    pass
-        if result.stdout.strip():
-            time.sleep(0.5)
-    except subprocess.TimeoutExpired:
-        pass
-    except FileNotFoundError:
-        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
-
 class ReviewHandler(BaseHTTPRequestHandler):
     """Serves the review HTML and handles feedback saves.
 
@@ -437,14 +413,12 @@ def main() -> None:
         print(f"\n  Static viewer written to: {args.static}\n")
         sys.exit(0)
 
-    # Kill any existing process on the target port
     port = args.port
-    _kill_port(port)
     handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
     try:
         server = HTTPServer(("127.0.0.1", port), handler)
     except OSError:
-        # Port still in use after kill attempt — find a free one
+        # Port in use (e.g. a previous viewer still running) — find a free one
         server = HTTPServer(("127.0.0.1", 0), handler)
         port = server.server_address[1]
 

--- a/plugins/agent-skills/skills/skill-forge/references/schemas.md
+++ b/plugins/agent-skills/skills/skill-forge/references/schemas.md
@@ -90,6 +90,8 @@ Output from `scripts/run_eval.py`.
 - `attempted_runs`: Runs requested for the query
 - `status`: `ok`, `partial_error`, `error`, or `not_run`
 - `pass`: Whether the observed trigger rate matches `should_trigger`
+- `timeouts`: Optional number of runs that hit the timeout window (counted as
+  non-trigger runs)
 - `errors`: Optional list of run error messages
 - `error_count`: Optional number of failed runs
 

--- a/plugins/agent-skills/skills/skill-forge/references/trigger_eval_boundaries.md
+++ b/plugins/agent-skills/skills/skill-forge/references/trigger_eval_boundaries.md
@@ -11,6 +11,8 @@ Each query result has these fields:
 - `attempted_runs`: Number of runs requested for the query.
 - `runs`: Number of runs that returned a trigger/non-trigger result without raising.
 - `triggers`: Number of successful runs where the detector saw a trigger signal.
+- `timeouts`: Number of runs where the observation window elapsed without a
+  decisive event. Present only when non-zero. See "Timeouts" below.
 - `trigger_rate`: `triggers / runs`, or `0.0` when `runs` is `0`.
 - `status`: Execution status.
   - `ok`: At least one successful run and no run errors.
@@ -21,6 +23,32 @@ Each query result has these fields:
 A successful non-trigger is `status: "ok"`, `runs > 0`, and `triggers == 0`.
 
 An eval infrastructure failure is `status: "error"` or `status: "not_run"` with `runs == 0`. Treat it as failed even when `should_trigger` is `false`.
+
+## Timeouts
+
+A run that reaches the `--timeout` window without a trigger signal counts as a
+non-trigger run: trigger decisions happen early in a session, so a long
+trigger-free window is treated as evidence of non-trigger rather than as an
+error. The run still increments `runs` and keeps `status: "ok"`.
+
+This is a bias to watch: a hung or slow CLI makes every `should_trigger`
+query fail and every `should_not_trigger` query pass. When `timeouts` is
+non-zero on failing positive queries, or `timeouts == runs` across the board,
+raise `--timeout` or investigate the CLI before trusting the scores.
+
+## Same-name skill masking
+
+While an eval batch runs, `run_eval` temporarily moves a project-installed
+skill with the same name (`.claude/skills/<name>` for Claude,
+`.agents/skills/<name>` for Codex) into a sibling `skill-forge-masked-<pid>`
+directory and restores it when the batch finishes. Without this, the installed
+skill stays visible next to the temporary skill under test: the agent may
+consult the installed copy, which carries the original description (and, for
+Codex, no marker), contaminating the measurement.
+
+If the process is killed hard mid-batch, the restore may not run. Recover by
+moving the skill directory back from `skill-forge-masked-<pid>` to its
+original location.
 
 ## Claude Code detector
 

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 from scripts.run_eval_claude import run_single_query_claude
 from scripts.run_eval_codex import run_single_query_codex
+from scripts.trigger_probe import TIMEOUT, TRIGGERED
 from scripts.utils import (
     CLI_CLAUDE,
     CLI_CODEX,
     detect_cli,
     find_project_root,
+    mask_installed_skill,
     parse_skill_md,
 )
 
@@ -27,10 +29,12 @@ def run_single_query(
     model: str | None = None,
     cli_type: str = CLI_CLAUDE,
     cli_command: str | None = None,
-) -> bool:
-    """Run a single query and return whether the skill was triggered.
+    source_skill_dir: str | None = None,
+) -> str:
+    """Run a single query and return the trigger outcome.
 
-    Dispatches to the appropriate CLI-specific implementation.
+    Dispatches to the appropriate CLI-specific implementation and returns
+    TRIGGERED, COMPLETED, or TIMEOUT.
     """
     if cli_type == CLI_CODEX:
         return run_single_query_codex(
@@ -39,7 +43,7 @@ def run_single_query(
         )
     return run_single_query_claude(
         query, skill_name, skill_description, timeout, project_root, model,
-        cli_command,
+        cli_command, source_skill_dir=source_skill_dir,
     )
 
 
@@ -58,39 +62,42 @@ def run_eval(
 ) -> dict:
     """Run the full eval set and return results."""
     results = []
-    query_triggers: dict[str, list[bool]] = {}
+    query_outcomes: dict[str, list[str]] = {}
     query_errors: dict[str, list[str]] = {}
     query_items: dict[str, dict] = {}
 
-    with ProcessPoolExecutor(max_workers=num_workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            query = item["query"]
-            query_triggers.setdefault(query, [])
-            query_errors.setdefault(query, [])
-            query_items[query] = item
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_query,
-                    item["query"],
-                    skill_name,
-                    description,
-                    timeout,
-                    str(project_root),
-                    model,
-                    cli_type,
-                    cli_command,
-                )
-                future_to_info[future] = (item, run_idx)
+    with mask_installed_skill(cli_type, skill_name, project_root) as masked_skill_dir:
+        source_skill_dir = str(masked_skill_dir) if masked_skill_dir else None
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            future_to_info = {}
+            for item in eval_set:
+                query = item["query"]
+                query_outcomes.setdefault(query, [])
+                query_errors.setdefault(query, [])
+                query_items[query] = item
+                for run_idx in range(runs_per_query):
+                    future = executor.submit(
+                        run_single_query,
+                        item["query"],
+                        skill_name,
+                        description,
+                        timeout,
+                        str(project_root),
+                        model,
+                        cli_type,
+                        cli_command,
+                        source_skill_dir,
+                    )
+                    future_to_info[future] = (item, run_idx)
 
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print(f"Error: query failed: {e}", file=sys.stderr)
-                query_errors[query].append(str(e))
+            for future in as_completed(future_to_info):
+                item, _ = future_to_info[future]
+                query = item["query"]
+                try:
+                    query_outcomes[query].append(future.result())
+                except Exception as e:
+                    print(f"Error: query failed: {e}", file=sys.stderr)
+                    query_errors[query].append(str(e))
 
     total_errors = sum(len(errs) for errs in query_errors.values())
     if total_errors > 0:
@@ -100,12 +107,25 @@ def run_eval(
             file=sys.stderr,
         )
 
-    for query, triggers in query_triggers.items():
+    total_timeouts = sum(
+        outcomes.count(TIMEOUT) for outcomes in query_outcomes.values()
+    )
+    if total_timeouts > 0:
+        print(
+            f"Warning: {total_timeouts} run(s) hit the {timeout}s timeout before "
+            f"a decisive event and count as non-triggers. Raise --timeout if "
+            f"should-trigger queries are affected.",
+            file=sys.stderr,
+        )
+
+    for query, outcomes in query_outcomes.items():
         item = query_items[query]
         errors = query_errors.get(query, [])
-        effective_runs = len(triggers)
+        effective_runs = len(outcomes)
+        triggers = outcomes.count(TRIGGERED)
+        timeouts = outcomes.count(TIMEOUT)
         if effective_runs > 0:
-            trigger_rate = sum(triggers) / effective_runs
+            trigger_rate = triggers / effective_runs
         else:
             trigger_rate = 0.0
         should_trigger = item["should_trigger"]
@@ -127,12 +147,14 @@ def run_eval(
             "query": query,
             "should_trigger": should_trigger,
             "trigger_rate": trigger_rate,
-            "triggers": sum(triggers),
+            "triggers": triggers,
             "runs": effective_runs,
             "attempted_runs": runs_per_query,
             "status": status,
             "pass": did_pass,
         }
+        if timeouts:
+            result_entry["timeouts"] = timeouts
         if errors:
             result_entry["errors"] = errors
             result_entry["error_count"] = len(errors)
@@ -150,6 +172,7 @@ def run_eval(
             "passed": passed,
             "failed": total - passed,
             "errors": total_errors,
+            "timeouts": total_timeouts,
         },
     }
 

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval_claude.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval_claude.py
@@ -2,13 +2,12 @@
 
 import json
 import os
-import select
 import shutil
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
+from scripts.trigger_probe import COMPLETED, TRIGGERED, watch_process
 from scripts.utils import CLI_CLAUDE, get_cli_command, resolve_skill_dir
 
 
@@ -51,6 +50,72 @@ def _write_skill_under_test(skill_file: Path, skill_name: str, skill_description
     skill_file.write_text(skill_content)
 
 
+def _make_claude_classifier(skill_name: str, skills_dir: Path):
+    """Build a stateful classifier for Claude stream-json events."""
+    pending_tool = ""
+    accumulated_json = ""
+
+    def classify(event: dict) -> str | None:
+        nonlocal pending_tool, accumulated_json
+
+        event_type = event.get("type")
+        if event_type == "stream_event":
+            se = event.get("event", {})
+            se_type = se.get("type", "")
+
+            if se_type == "content_block_start":
+                cb = se.get("content_block", {})
+                if cb.get("type") == "tool_use" and cb.get("name", "") in ("Skill", "Read"):
+                    pending_tool = cb.get("name", "")
+                    accumulated_json = ""
+
+            elif se_type == "content_block_delta" and pending_tool:
+                delta = se.get("delta", {})
+                if delta.get("type") == "input_json_delta":
+                    accumulated_json += delta.get("partial_json", "")
+                    try:
+                        tool_input = json.loads(accumulated_json)
+                    except json.JSONDecodeError:
+                        return None
+                    if _is_expected_claude_tool_input(
+                        pending_tool, tool_input, skill_name, skills_dir,
+                    ):
+                        return TRIGGERED
+
+            elif se_type in ("content_block_stop", "message_stop"):
+                if pending_tool:
+                    try:
+                        tool_input = json.loads(accumulated_json)
+                    except json.JSONDecodeError:
+                        tool_input = {}
+                    matched = _is_expected_claude_tool_input(
+                        pending_tool, tool_input, skill_name, skills_dir,
+                    )
+                    pending_tool = ""
+                    accumulated_json = ""
+                    if matched:
+                        return TRIGGERED
+
+        elif event_type == "assistant":
+            for content_item in event.get("message", {}).get("content", []):
+                if content_item.get("type") != "tool_use":
+                    continue
+                if _is_expected_claude_tool_input(
+                    content_item.get("name", ""),
+                    content_item.get("input", {}),
+                    skill_name,
+                    skills_dir,
+                ):
+                    return TRIGGERED
+
+        elif event_type == "result":
+            return COMPLETED
+
+        return None
+
+    return classify
+
+
 def run_single_query_claude(
     query: str,
     skill_name: str,
@@ -59,19 +124,27 @@ def run_single_query_claude(
     project_root: str,
     model: str | None = None,
     cli_command: str | None = None,
-) -> bool:
-    """Run a single query via Claude Code and return whether the skill was triggered."""
+    source_skill_dir: str | None = None,
+) -> str:
+    """Run a single query via Claude Code and classify the trigger outcome.
+
+    Returns TRIGGERED, COMPLETED, or TIMEOUT. `source_skill_dir` overrides
+    where supporting files are copied from (used while the installed skill is
+    masked during an eval batch).
+    """
     project_root_path = Path(project_root)
-    source_skills_dir = resolve_skill_dir(CLI_CLAUDE, project_root_path)
     temp_claude_home = Path(tempfile.mkdtemp(prefix="skill-forge-claude-home-", dir=project_root_path))
     temp_skills_dir = temp_claude_home / "skills"
     temp_skill_dir = temp_skills_dir / skill_name
     skill_file = temp_skill_dir / "SKILL.md"
 
     try:
-        source_skill_dir = source_skills_dir / skill_name
-        if source_skill_dir.exists():
-            shutil.copytree(source_skill_dir, temp_skill_dir)
+        if source_skill_dir is not None:
+            source_dir = Path(source_skill_dir)
+        else:
+            source_dir = resolve_skill_dir(CLI_CLAUDE, project_root_path) / skill_name
+        if source_dir.exists():
+            shutil.copytree(source_dir, temp_skill_dir)
         else:
             temp_skill_dir.mkdir(parents=True, exist_ok=True)
         _write_skill_under_test(skill_file, skill_name, skill_description)
@@ -90,120 +163,20 @@ def run_single_query_claude(
         env["SKILL_FORGE_CLAUDE_HOME"] = str(temp_claude_home)
         env["CLAUDE_CONFIG_DIR"] = str(temp_claude_home)
 
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=project_root,
-            env=env,
-        )
-
-        triggered = False
-        start_time = time.time()
-        buffer = ""
-        pending_tool_name = None
-        accumulated_json = ""
-
-        try:
-            while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
-                    continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
-
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
-
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                try:
-                                    tool_input = json.loads(accumulated_json)
-                                except json.JSONDecodeError:
-                                    continue
-                                if _is_expected_claude_tool_input(
-                                    pending_tool_name,
-                                    tool_input,
-                                    skill_name,
-                                    temp_skills_dir,
-                                ):
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                try:
-                                    tool_input = json.loads(accumulated_json)
-                                except json.JSONDecodeError:
-                                    tool_input = {}
-                                if _is_expected_claude_tool_input(
-                                    pending_tool_name,
-                                    tool_input,
-                                    skill_name,
-                                    temp_skills_dir,
-                                ):
-                                    return True
-                                pending_tool_name = None
-                                accumulated_json = ""
-
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            if _is_expected_claude_tool_input(
-                                content_item.get("name", ""),
-                                content_item.get("input", {}),
-                                skill_name,
-                                temp_skills_dir,
-                            ):
-                                triggered = True
-                                return True
-
-                    elif event.get("type") == "result":
-                        return triggered
-        finally:
-            killed = False
-            if process.poll() is None:
-                process.kill()
-                process.wait()
-                killed = True
-            if not killed and process.returncode and process.returncode != 0:
-                stderr_output = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""
-                raise RuntimeError(
-                    f"Claude CLI exited with code {process.returncode}: {stderr_output[:500]}"
-                )
-
-        return triggered
+        with tempfile.TemporaryFile() as stderr_sink:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=stderr_sink,
+                cwd=project_root,
+                env=env,
+            )
+            return watch_process(
+                process,
+                timeout=timeout,
+                classify=_make_claude_classifier(skill_name, temp_skills_dir),
+                label="Claude CLI",
+                stderr_sink=stderr_sink,
+            )
     finally:
         shutil.rmtree(temp_claude_home, ignore_errors=True)

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval_codex.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval_codex.py
@@ -1,15 +1,29 @@
 """Codex-specific trigger evaluation helpers."""
 
-import json
-import os
-import select
 import shutil
 import subprocess
-import time
+import tempfile
 import uuid
 from pathlib import Path
 
+from scripts.trigger_probe import COMPLETED, TRIGGERED, watch_process
 from scripts.utils import CLI_CODEX, get_cli_command, resolve_skill_dir
+
+
+def _make_codex_classifier(marker: str):
+    """Build a classifier for Codex exec JSON events."""
+
+    def classify(event: dict) -> str | None:
+        event_type = event.get("type", "")
+        if event_type in ("item.completed", "item.updated"):
+            item = event.get("item", {})
+            if item.get("type") == "agent_message" and marker in item.get("text", ""):
+                return TRIGGERED
+        elif event_type == "turn.completed":
+            return COMPLETED
+        return None
+
+    return classify
 
 
 def run_single_query_codex(
@@ -20,8 +34,11 @@ def run_single_query_codex(
     project_root: str,
     model: str | None = None,
     cli_command: str | None = None,
-) -> bool:
-    """Run a single query via Codex CLI and return whether the skill was triggered."""
+) -> str:
+    """Run a single query via Codex CLI and classify the trigger outcome.
+
+    Returns TRIGGERED, COMPLETED, or TIMEOUT.
+    """
     project_root_path = Path(project_root)
     unique_id = uuid.uuid4().hex[:8]
     marker = f"[SKILL_TRIGGERED:{unique_id}]"
@@ -57,66 +74,20 @@ def run_single_query_codex(
         if model:
             cmd.extend(["-m", model])
 
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=project_root,
-        )
-
-        start_time = time.time()
-        buffer = ""
-
-        try:
-            while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
-                    continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
-
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
-
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    event_type = event.get("type", "")
-                    if event_type in ("item.completed", "item.updated"):
-                        item = event.get("item", {})
-                        if item.get("type") == "agent_message":
-                            text = item.get("text", "")
-                            if marker in text:
-                                return True
-                    elif event_type == "turn.completed":
-                        return False
-
-            return False
-        finally:
-            killed = False
-            if process.poll() is None:
-                process.kill()
-                process.wait()
-                killed = True
-            if not killed and process.returncode and process.returncode != 0:
-                stderr_output = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""
-                raise RuntimeError(
-                    f"Codex CLI exited with code {process.returncode}: {stderr_output[:500]}"
-                )
+        with tempfile.TemporaryFile() as stderr_sink:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=stderr_sink,
+                cwd=project_root,
+            )
+            return watch_process(
+                process,
+                timeout=timeout,
+                classify=_make_codex_classifier(marker),
+                label="Codex CLI",
+                stderr_sink=stderr_sink,
+            )
     finally:
         if skill_dir.exists():
             shutil.rmtree(skill_dir, ignore_errors=True)

--- a/plugins/agent-skills/skills/skill-forge/scripts/trigger_probe.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/trigger_probe.py
@@ -1,0 +1,91 @@
+"""Shared subprocess JSON-event streaming for trigger evaluations.
+
+Both CLI runners stream newline-delimited JSON events from a child process
+and classify them into a trigger outcome. This module owns that loop so the
+buffering, timeout, and process-cleanup behavior stays identical across CLIs.
+"""
+
+import json
+import os
+import select
+import time
+
+# Trigger probe outcomes.
+TRIGGERED = "triggered"  # the detector saw the skill being consulted
+COMPLETED = "completed"  # the run finished without a trigger signal
+TIMEOUT = "timeout"  # the observation window elapsed without a decisive event
+
+
+def _classify_line(line: str, classify) -> str | None:
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return classify(event)
+
+
+def watch_process(process, timeout: int, classify, label: str, stderr_sink=None) -> str:
+    """Stream JSON-line events from process stdout and classify them.
+
+    `classify(event)` returns TRIGGERED, COMPLETED, or None to keep reading.
+    Returns the outcome: TRIGGERED, COMPLETED (decisive end or process exit
+    without a trigger), or TIMEOUT when the window elapses first.
+
+    Raises RuntimeError when the process exits non-zero without triggering;
+    `stderr_sink` (a file object the caller wired as the process stderr) is
+    read for the error message.
+    """
+    outcome = None
+    buffer = ""
+    deadline = time.monotonic() + timeout
+
+    try:
+        while outcome is None:
+            if time.monotonic() >= deadline:
+                outcome = TIMEOUT
+                break
+
+            exited = process.poll() is not None
+            if exited:
+                remaining = process.stdout.read()
+                if remaining:
+                    buffer += remaining.decode("utf-8", errors="replace")
+            else:
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if chunk:
+                    buffer += chunk.decode("utf-8", errors="replace")
+                else:
+                    exited = True
+
+            while outcome is None and "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                outcome = _classify_line(line, classify)
+
+            if outcome is None and exited:
+                # Classify a trailing line without a newline before concluding.
+                outcome = _classify_line(buffer, classify) or COMPLETED
+    finally:
+        killed = False
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+            killed = True
+        if outcome != TRIGGERED and not killed and process.returncode:
+            stderr_text = ""
+            if stderr_sink is not None:
+                try:
+                    stderr_sink.seek(0)
+                    stderr_text = stderr_sink.read().decode("utf-8", errors="replace")
+                except (OSError, ValueError):
+                    stderr_text = ""
+            raise RuntimeError(
+                f"{label} exited with code {process.returncode}: {stderr_text[:500]}"
+            )
+
+    return outcome

--- a/plugins/agent-skills/skills/skill-forge/scripts/utils.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/utils.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 CLI_CLAUDE = "claude"
@@ -104,6 +105,57 @@ def resolve_skill_dir(cli_type: str, project_root: Path | None = None) -> Path:
         base_root = project_root if project_root is not None else find_project_root(cli_type)
         return base_root / ".agents" / "skills"
     return resolve_cli_home(cli_type, project_root) / "skills"
+
+
+def project_skill_install_dir(cli_type: str, project_root: Path) -> Path:
+    """Return the project-level skills directory the CLI discovers from cwd.
+
+    Unlike resolve_skill_dir, home-directory overrides are irrelevant here:
+    trigger evals run the CLI with cwd at the project root, and the CLI always
+    discovers this path regardless of any home override.
+    """
+    if cli_type == CLI_CODEX:
+        return project_root / ".agents" / "skills"
+    return project_root / ".claude" / "skills"
+
+
+@contextmanager
+def mask_installed_skill(cli_type: str, skill_name: str, project_root: Path):
+    """Temporarily move a same-named installed skill out of CLI discovery.
+
+    Trigger evals present the description under test through a temporary
+    skill. When the real skill is also installed in the project, both are
+    visible under the same name and the real one contaminates the
+    measurement (for Codex it even shadows the marker), so it is moved aside
+    for the duration and restored afterwards.
+
+    Yields the masked location (usable as a copy source), or None when the
+    skill is not installed in the project.
+    """
+    installed = project_skill_install_dir(cli_type, project_root) / skill_name
+    if not (installed.is_symlink() or installed.exists()):
+        yield None
+        return
+
+    # The mask dir sits at the same depth as the skills dir so relative
+    # symlink targets keep resolving from the masked location.
+    mask_root = installed.parent.parent / f"skill-forge-masked-{os.getpid()}"
+    mask_root.mkdir(parents=True, exist_ok=True)
+    masked = mask_root / skill_name
+    installed.rename(masked)
+    print(
+        f"Note: temporarily moved {installed} to {masked} during the trigger "
+        "eval; it is restored automatically when the eval finishes.",
+        file=sys.stderr,
+    )
+    try:
+        yield masked
+    finally:
+        masked.rename(installed)
+        try:
+            mask_root.rmdir()
+        except OSError:
+            pass
 
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
@@ -23,23 +23,23 @@ SKILL_NAME = "skill-forge"
 
 class TestRunSingleQueryDispatch:
     def test_dispatches_to_claude(self):
-        with patch("scripts.run_eval.run_single_query_claude", return_value=True) as mock:
+        with patch("scripts.run_eval.run_single_query_claude", return_value="triggered") as mock:
             result = run_single_query(
                 "test query", "skill", "desc", 10, "/tmp", cli_type=CLI_CLAUDE,
             )
-            assert result is True
+            assert result == "triggered"
             mock.assert_called_once()
 
     def test_dispatches_to_codex(self):
-        with patch("scripts.run_eval.run_single_query_codex", return_value=False) as mock:
+        with patch("scripts.run_eval.run_single_query_codex", return_value="completed") as mock:
             result = run_single_query(
                 "test query", "skill", "desc", 10, "/tmp", cli_type=CLI_CODEX,
             )
-            assert result is False
+            assert result == "completed"
             mock.assert_called_once()
 
     def test_passes_cli_command_to_claude(self):
-        with patch("scripts.run_eval.run_single_query_claude", return_value=True) as mock:
+        with patch("scripts.run_eval.run_single_query_claude", return_value="triggered") as mock:
             run_single_query(
                 "q", "s", "d", 10, "/tmp",
                 cli_type=CLI_CLAUDE, cli_command="/custom/claude",
@@ -48,7 +48,7 @@ class TestRunSingleQueryDispatch:
             assert args[-1] == "/custom/claude"
 
     def test_passes_cli_command_to_codex(self):
-        with patch("scripts.run_eval.run_single_query_codex", return_value=True) as mock:
+        with patch("scripts.run_eval.run_single_query_codex", return_value="triggered") as mock:
             run_single_query(
                 "q", "s", "d", 10, "/tmp",
                 cli_type=CLI_CODEX, cli_command="/custom/codex",
@@ -77,7 +77,7 @@ class TestCodexCommandArgs:
             return mock_proc
 
         with patch("scripts.run_eval_codex.subprocess.Popen", side_effect=capture_popen):
-            with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 run_single_query_codex(
                     "test query", "my-skill", "test desc", 5, str(project_root),
                 )
@@ -102,7 +102,7 @@ class TestCodexCommandArgs:
             return mock_proc
 
         with patch("scripts.run_eval_codex.subprocess.Popen", side_effect=capture_popen):
-            with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 run_single_query_codex(
                     "test query", "my-skill", "test desc", 5, str(project_root),
                 )
@@ -129,7 +129,7 @@ class TestCliExitCodeHandling:
         mock_process.returncode = 1
 
         with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 with pytest.raises(RuntimeError, match="Codex CLI exited with code 1"):
                     run_single_query_codex(
                         "test query", "my-skill", "test desc", 5, str(project_root),
@@ -145,7 +145,7 @@ class TestCliExitCodeHandling:
         def mock_run(query, *args, **kwargs):
             if query == "error query":
                 raise RuntimeError("CLI crashed")
-            return True
+            return "triggered"
 
         with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
             with patch("scripts.run_eval.run_single_query", side_effect=mock_run):
@@ -195,13 +195,13 @@ class TestRunSingleQueryClaude:
         mock_process, output = self._make_process_mock(events)
 
         with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_claude.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_claude(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
 
-        assert result is True
+        assert result == "triggered"
 
     def test_detects_stream_event_skill_tool_use(self, tmp_path):
         project_root = tmp_path / "project"
@@ -233,13 +233,13 @@ class TestRunSingleQueryClaude:
         mock_process, output = self._make_process_mock(events)
 
         with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_claude.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_claude(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
 
-        assert result is True
+        assert result == "triggered"
 
     def test_stream_event_shape_change_does_not_trigger(self, tmp_path):
         project_root = tmp_path / "project"
@@ -261,13 +261,13 @@ class TestRunSingleQueryClaude:
         mock_process, output = self._make_process_mock(events)
 
         with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_claude.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_claude(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
 
-        assert result is False
+        assert result == "completed"
 
     def test_ignores_non_matching_tool_before_skill_trigger(self, tmp_path):
         project_root = tmp_path / "project"
@@ -295,13 +295,13 @@ class TestRunSingleQueryClaude:
         mock_process, output = self._make_process_mock(events)
 
         with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_claude.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_claude(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
 
-        assert result is True
+        assert result == "triggered"
 
     def test_detects_skill_path_from_read_tool_use(self, tmp_path):
         project_root = tmp_path / "project"
@@ -327,13 +327,13 @@ class TestRunSingleQueryClaude:
         mock_process, output = self._make_process_mock(events)
 
         with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_claude.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_claude(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
 
-        assert result is True
+        assert result == "triggered"
 
     def test_uses_isolated_workspace_for_temp_skill_even_with_override(self, tmp_path):
         project_root = tmp_path / "project"
@@ -354,13 +354,13 @@ class TestRunSingleQueryClaude:
                 return mock_process
 
             with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
-                with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                    with patch("scripts.run_eval_claude.os.read", return_value=output):
+                with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.trigger_probe.os.read", return_value=output):
                         result = run_single_query_claude(
                             "test query", SKILL_NAME, "test desc", 5, str(project_root),
                         )
 
-        assert result is False
+        assert result == "completed"
         assert observed["cwd"] == project_root
         assert observed["claude_home"].parent == project_root
         assert observed["claude_config_dir"] == observed["claude_home"]
@@ -397,13 +397,13 @@ class TestRunSingleQueryClaude:
             return mock_process
 
         with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
-            with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_claude.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_claude(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
 
-        assert result is False
+        assert result == "completed"
         assert "description: |\n  test desc\n" in observed["skill_md"]
         assert "old desc" not in observed["skill_md"]
         assert observed["supporting_file"] == "supporting file"
@@ -434,13 +434,13 @@ class TestRunSingleQueryClaude:
 
         with patch.dict(os.environ, {"SKILL_FORGE_CLAUDE_HOME": str(claude_home)}, clear=True):
             with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
-                with patch("scripts.run_eval_claude.select.select", return_value=([mock_process.stdout], [], [])):
-                    with patch("scripts.run_eval_claude.os.read", return_value=output):
+                with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.trigger_probe.os.read", return_value=output):
                         result = run_single_query_claude(
                             "test query", SKILL_NAME, "test desc", 5, str(project_root),
                         )
 
-        assert result is True
+        assert result == "triggered"
 
 
 class TestRunSingleQueryCodex:
@@ -467,12 +467,12 @@ class TestRunSingleQueryCodex:
         mock_process = self._make_process_mock(events)
 
         with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 result = run_single_query_codex(
                     "test query", "my-skill", "test desc", 5, str(project_root),
                 )
 
-        assert result is False
+        assert result == "completed"
         # Temp skill dir should be cleaned up
         skill_dirs = list((project_root / ".agents" / "skills").iterdir())
         assert len(skill_dirs) == 0
@@ -489,12 +489,12 @@ class TestRunSingleQueryCodex:
 
         with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=True):
             with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-                with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+                with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                     result = run_single_query_codex(
                         "test query", "my-skill", "test desc", 5, str(project_root),
                     )
 
-        assert result is False
+        assert result == "completed"
         assert not (codex_home / "skills").exists()
         assert not (project_root / ".codex").exists()
         assert (project_root / ".agents" / "skills").is_dir()
@@ -524,13 +524,13 @@ class TestRunSingleQueryCodex:
             mock_process.returncode = 0
 
             with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-                with patch("scripts.run_eval_codex.select.select", return_value=([mock_process.stdout], [], [])):
-                    with patch("scripts.run_eval_codex.os.read", return_value=output):
+                with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.trigger_probe.os.read", return_value=output):
                         result = run_single_query_codex(
                             "test query", "my-skill", "test desc", 5, str(project_root),
                         )
 
-            assert result is True
+            assert result == "triggered"
 
     def test_detects_marker_in_updated_agent_message(self, tmp_path):
         project_root = tmp_path / "project"
@@ -553,13 +553,13 @@ class TestRunSingleQueryCodex:
             mock_process.returncode = 0
 
             with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-                with patch("scripts.run_eval_codex.select.select", return_value=([mock_process.stdout], [], [])):
-                    with patch("scripts.run_eval_codex.os.read", return_value=output):
+                with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.trigger_probe.os.read", return_value=output):
                         result = run_single_query_codex(
                             "test query", "my-skill", "test desc", 5, str(project_root),
                         )
 
-            assert result is True
+            assert result == "triggered"
 
     def test_codex_event_shape_change_does_not_trigger(self, tmp_path):
         project_root = tmp_path / "project"
@@ -586,13 +586,13 @@ class TestRunSingleQueryCodex:
             mock_process.returncode = 0
 
             with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-                with patch("scripts.run_eval_codex.select.select", return_value=([mock_process.stdout], [], [])):
-                    with patch("scripts.run_eval_codex.os.read", return_value=output):
+                with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                    with patch("scripts.trigger_probe.os.read", return_value=output):
                         result = run_single_query_codex(
                             "test query", "my-skill", "test desc", 5, str(project_root),
                         )
 
-            assert result is False
+            assert result == "completed"
 
     def test_no_trigger_returns_false(self, tmp_path):
         """No marker in output means not triggered."""
@@ -613,13 +613,13 @@ class TestRunSingleQueryCodex:
         mock_process.returncode = 0
 
         with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
-            with patch("scripts.run_eval_codex.select.select", return_value=([mock_process.stdout], [], [])):
-                with patch("scripts.run_eval_codex.os.read", return_value=output):
+            with patch("scripts.trigger_probe.select.select", return_value=([mock_process.stdout], [], [])):
+                with patch("scripts.trigger_probe.os.read", return_value=output):
                     result = run_single_query_codex(
                         "test query", "my-skill", "test desc", 5, str(project_root),
                     )
 
-        assert result is False
+        assert result == "completed"
 
 
 class TestRunEval:
@@ -631,7 +631,7 @@ class TestRunEval:
         ]
 
         def mock_run_single(query, *args, **kwargs):
-            return query == "trigger me"
+            return "triggered" if query == "trigger me" else "completed"
 
         # Patch ProcessPoolExecutor to use ThreadPoolExecutor (avoids pickle issues)
         with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
@@ -660,9 +660,9 @@ class TestRunEval:
             {"query": "should not trigger", "should_trigger": False},
         ]
 
-        # Both return False
+        # Both complete without triggering
         with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
-            with patch("scripts.run_eval.run_single_query", return_value=False):
+            with patch("scripts.run_eval.run_single_query", return_value="completed"):
                 result = run_eval(
                     eval_set=eval_set,
                     skill_name="test",
@@ -685,7 +685,7 @@ class TestRunEval:
 
         def capture_call(*args, **kwargs):
             calls.append((args, kwargs))
-            return True
+            return "triggered"
 
         with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
             with patch("scripts.run_eval.run_single_query", side_effect=capture_call):
@@ -703,7 +703,8 @@ class TestRunEval:
 
         assert len(calls) == 1
         args, _ = calls[0]
-        # args: query, skill_name, description, timeout, project_root, model, cli_type, cli_command
+        # args: query, skill_name, description, timeout, project_root, model,
+        #       cli_type, cli_command, source_skill_dir
         assert args[6] == CLI_CODEX
         assert args[7] == "/custom/codex"
 
@@ -714,7 +715,7 @@ class TestRunEval:
         def count_calls(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            return True
+            return "triggered"
 
         with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
             with patch("scripts.run_eval.run_single_query", side_effect=count_calls):
@@ -804,7 +805,7 @@ class TestTemporarySkillNames:
 
         with patch.dict(os.environ, {}, clear=True):
             with patch("scripts.run_eval_codex.subprocess.Popen", side_effect=capture_popen):
-                with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+                with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                     run_single_query_codex(
                         "test query", SKILL_NAME, "test desc", 5, str(project_root),
                     )
@@ -833,7 +834,7 @@ class TestTemporarySkillNames:
             return mock_process
 
         with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
-            with patch("scripts.run_eval_claude.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 run_single_query_claude(
                     "test query", SKILL_NAME, "test desc", 5, str(project_root),
                 )
@@ -867,7 +868,7 @@ class TestTemporarySkillNames:
 
         with patch.dict(os.environ, {}, clear=True):
             with patch("scripts.run_eval_codex.subprocess.Popen", side_effect=capture_popen):
-                with patch("scripts.run_eval_codex.select.select", return_value=([], [], [])):
+                with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                     with ThreadPoolExecutor(max_workers=2) as executor:
                         futures = [
                             executor.submit(
@@ -881,7 +882,7 @@ class TestTemporarySkillNames:
                             for _ in range(2)
                         ]
                         for future in futures:
-                            assert future.result() is False
+                            assert future.result() == "completed"
 
         assert len(observed_snapshots) == 2
         assert all(len(snapshot) == 2 for snapshot in observed_snapshots)
@@ -911,7 +912,7 @@ class TestTemporarySkillNames:
             return mock_process
 
         with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
-            with patch("scripts.run_eval_claude.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 with ThreadPoolExecutor(max_workers=2) as executor:
                     futures = [
                         executor.submit(
@@ -925,7 +926,7 @@ class TestTemporarySkillNames:
                         for _ in range(2)
                     ]
                     for future in futures:
-                        assert future.result() is False
+                        assert future.result() == "completed"
 
         assert len(observed_paths) == 2
         assert len({path for path, _ in observed_paths}) == 2
@@ -949,12 +950,148 @@ class TestTemporarySkillNames:
             return mock_process
 
         with patch("scripts.run_eval_claude.subprocess.Popen", side_effect=capture_popen):
-            with patch("scripts.run_eval_claude.select.select", return_value=([], [], [])):
+            with patch("scripts.trigger_probe.select.select", return_value=([], [], [])):
                 result = run_single_query_claude(
                     "test query", SKILL_NAME, "test desc", 5, str(project_root),
                 )
 
-        assert result is False
+        assert result == "completed"
         assert observed["cwd"] == project_root
         assert observed["claude_home"].parent == project_root
         assert not observed["claude_home"].exists()
+
+
+class TestTimeoutOutcome:
+    def test_claude_timeout_returns_timeout_outcome(self, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+
+        with patch("scripts.run_eval_claude.subprocess.Popen", return_value=mock_process):
+            result = run_single_query_claude(
+                "test query", SKILL_NAME, "test desc", 0, str(project_root),
+            )
+
+        assert result == "timeout"
+        mock_process.kill.assert_called_once()
+
+    def test_codex_timeout_returns_timeout_outcome(self, tmp_path):
+        project_root = tmp_path / "project"
+        (project_root / ".agents" / "skills").mkdir(parents=True)
+
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+
+        with patch("scripts.run_eval_codex.subprocess.Popen", return_value=mock_process):
+            result = run_single_query_codex(
+                "test query", "my-skill", "test desc", 0, str(project_root),
+            )
+
+        assert result == "timeout"
+        mock_process.kill.assert_called_once()
+
+    def test_run_eval_counts_timeouts_as_non_triggers(self):
+        eval_set = [{"query": "slow query", "should_trigger": True}]
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
+            with patch("scripts.run_eval.run_single_query", return_value="timeout"):
+                result = run_eval(
+                    eval_set=eval_set,
+                    skill_name="test",
+                    description="desc",
+                    num_workers=1,
+                    timeout=10,
+                    project_root=Path("/tmp"),
+                    runs_per_query=2,
+                    trigger_threshold=0.5,
+                    cli_type=CLI_CLAUDE,
+                )
+
+        entry = result["results"][0]
+        assert entry["runs"] == 2
+        assert entry["triggers"] == 0
+        assert entry["timeouts"] == 2
+        assert entry["status"] == "ok"
+        assert entry["pass"] is False
+        assert result["summary"]["timeouts"] == 2
+
+    def test_run_eval_omits_timeouts_field_when_none(self):
+        eval_set = [{"query": "q", "should_trigger": True}]
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
+            with patch("scripts.run_eval.run_single_query", return_value="triggered"):
+                result = run_eval(
+                    eval_set=eval_set,
+                    skill_name="test",
+                    description="desc",
+                    num_workers=1,
+                    timeout=10,
+                    project_root=Path("/tmp"),
+                    runs_per_query=1,
+                    cli_type=CLI_CLAUDE,
+                )
+
+        assert "timeouts" not in result["results"][0]
+        assert result["summary"]["timeouts"] == 0
+
+
+class TestInstalledSkillMasking:
+    def _run_eval_with_capture(self, project_root, cli_type, installed):
+        captured = {}
+
+        def mock_run(*args, **kwargs):
+            captured["source_skill_dir"] = args[8]
+            captured["installed_hidden"] = not installed.exists()
+            return "completed"
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
+            with patch("scripts.run_eval.run_single_query", side_effect=mock_run):
+                run_eval(
+                    eval_set=[{"query": "q", "should_trigger": False}],
+                    skill_name="test",
+                    description="candidate desc",
+                    num_workers=1,
+                    timeout=10,
+                    project_root=project_root,
+                    runs_per_query=1,
+                    cli_type=cli_type,
+                )
+        return captured
+
+    def test_masks_installed_claude_skill_during_runs(self, tmp_path):
+        project_root = tmp_path / "project"
+        installed = project_root / ".claude" / "skills" / "test"
+        installed.mkdir(parents=True)
+        (installed / "SKILL.md").write_text("---\nname: test\ndescription: original\n---\n")
+
+        captured = self._run_eval_with_capture(project_root, CLI_CLAUDE, installed)
+
+        assert captured["installed_hidden"] is True
+        source = Path(captured["source_skill_dir"])
+        assert source.name == "test"
+        assert source.parent.name.startswith("skill-forge-masked-")
+        # Restored after the eval, mask dir cleaned up
+        assert (installed / "SKILL.md").exists()
+        assert not source.parent.exists()
+
+    def test_masks_installed_codex_skill_during_runs(self, tmp_path):
+        project_root = tmp_path / "project"
+        installed = project_root / ".agents" / "skills" / "test"
+        installed.mkdir(parents=True)
+        (installed / "SKILL.md").write_text("---\nname: test\ndescription: original\n---\n")
+
+        captured = self._run_eval_with_capture(project_root, CLI_CODEX, installed)
+
+        assert captured["installed_hidden"] is True
+        assert (installed / "SKILL.md").exists()
+
+    def test_no_masking_when_skill_not_installed(self, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        installed = project_root / ".claude" / "skills" / "test"
+
+        captured = self._run_eval_with_capture(project_root, CLI_CLAUDE, installed)
+
+        assert captured["source_skill_dir"] is None

--- a/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
@@ -13,7 +13,9 @@ from scripts.utils import (
     detect_cli,
     find_project_root,
     get_cli_command,
+    mask_installed_skill,
     parse_skill_md,
+    project_skill_install_dir,
     resolve_cli_home,
     resolve_skill_dir,
 )
@@ -287,3 +289,57 @@ class TestParseSkillMd:
         skill_md.write_text("---\nname: bad\n")
         with pytest.raises(ValueError, match="no closing"):
             parse_skill_md(tmp_path)
+
+
+class TestProjectSkillInstallDir:
+    def test_claude_uses_project_claude_skills(self, tmp_path):
+        assert project_skill_install_dir(CLI_CLAUDE, tmp_path) == tmp_path / ".claude" / "skills"
+
+    def test_codex_uses_project_agents_skills(self, tmp_path):
+        assert project_skill_install_dir(CLI_CODEX, tmp_path) == tmp_path / ".agents" / "skills"
+
+    def test_ignores_home_overrides(self, tmp_path):
+        with patch.dict(os.environ, {"SKILL_FORGE_CLAUDE_HOME": "/elsewhere"}):
+            assert project_skill_install_dir(CLI_CLAUDE, tmp_path) == tmp_path / ".claude" / "skills"
+
+
+class TestMaskInstalledSkill:
+    def test_noop_when_skill_not_installed(self, tmp_path):
+        with mask_installed_skill(CLI_CLAUDE, "ghost", tmp_path) as masked:
+            assert masked is None
+
+    def test_masks_and_restores_installed_skill(self, tmp_path):
+        installed = tmp_path / ".claude" / "skills" / "foo"
+        installed.mkdir(parents=True)
+        (installed / "SKILL.md").write_text("content")
+
+        with mask_installed_skill(CLI_CLAUDE, "foo", tmp_path) as masked:
+            assert not installed.exists()
+            assert (masked / "SKILL.md").read_text() == "content"
+
+        assert (installed / "SKILL.md").read_text() == "content"
+        assert not masked.parent.exists()
+
+    def test_restores_on_exception(self, tmp_path):
+        installed = tmp_path / ".agents" / "skills" / "foo"
+        installed.mkdir(parents=True)
+
+        with pytest.raises(RuntimeError):
+            with mask_installed_skill(CLI_CODEX, "foo", tmp_path):
+                raise RuntimeError("boom")
+
+        assert installed.exists()
+
+    def test_masked_relative_symlink_still_resolves(self, tmp_path):
+        real = tmp_path / "plugins" / "foo"
+        real.mkdir(parents=True)
+        (real / "SKILL.md").write_text("real content")
+        skills = tmp_path / ".claude" / "skills"
+        skills.mkdir(parents=True)
+        (skills / "foo").symlink_to(Path("..") / ".." / "plugins" / "foo")
+
+        with mask_installed_skill(CLI_CLAUDE, "foo", tmp_path) as masked:
+            assert (masked / "SKILL.md").read_text() == "real content"
+
+        assert (skills / "foo" / "SKILL.md").read_text() == "real content"
+        assert (skills / "foo").is_symlink()


### PR DESCRIPTION
## 概要

skill-forge のトリガー評価基盤に対する監査（thermo-nuclear code quality review）で見つかった致命的問題3件の修正です。

### 1. トリガー評価の隔離不備の修正（測定汚染）

評価対象スキルがプロジェクトにインストール済みの場合、一時スキルの隣に本物のスキルが同名のまま残り、測定を汚染していました。

- **Codex**: 本物（マーカーなし）が参照されると系統的な偽陰性になる
- **Claude**: `CLAUDE_CONFIG_DIR` を隔離してもプロジェクトレベルの `.claude/skills/` は cwd 経由で見え続け、元の description 経由のトリガーが候補 description の成果として計上される

`run_eval` が評価バッチ実行中のみ同名スキルを隣接の `skill-forge-masked-<pid>/` に退避し、終了時に自動復元するようにしました（相対symlink構成でもリンクが切れないよう同一深度に配置）。

### 2. eval viewer のポート kill を削除

`generate_review.py` がポート3117上の任意プロセスを無差別に SIGTERM していました。既存の「バインド失敗時は空きポートへフォールバック」処理に委譲し、`_kill_port` を削除しました。

### 3. timeout の可観測化 + ストリーミング共通化

- ランナーの戻り値を bool から outcome（`triggered` / `completed` / `timeout`）に変更。timeout は従来通り非トリガー観測として集計されますが、結果JSONの `timeouts` フィールドと警告で CLI ハング起因の偽スコアを検出可能にしました
- Claude/Codex で重複していた subprocess ストリーミングループを `scripts/trigger_probe.py` に統合
- 統合に伴い潜在バグ2件を解消: 高速終了する CLI の最終バッファのイベント破棄（偽陰性・flaky 要因）、stderr パイプ未 drain によるストール

## テスト

- `bash scripts/ci/verify.sh`: ユニットテスト 119 件パス + スキルバリデーション（auto / codex strict）通過
- 実プロセスによる `watch_process` スモークテスト6シナリオ（trigger中断 / 終了バッファ / 非トリガー / timeout / 非ゼロ終了 / 改行なし末尾行）確認済み

## ドキュメント

- `references/trigger_eval_boundaries.md`: 「Timeouts」「Same-name skill masking」セクション追加（SIGKILL時の復旧手順含む）
- `references/schemas.md`: `timeouts` フィールド追記

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect measurement correctness for trigger evals (filesystem moves during batches) and shared subprocess handling; regressions could skew pass/fail scores or leave skills masked after SIGKILL, though behavior is documented and heavily tested.
> 
> **Overview**
> This PR hardens **skill-forge** trigger evaluation so scores reflect the description under test, not side effects of the local environment or opaque CLI behavior.
> 
> **Trigger eval isolation:** While a batch runs, `run_eval` temporarily moves a same-named project-installed skill (`.claude/skills/` or `.agents/skills/`) into `skill-forge-masked-<pid>/` and restores it afterward. Claude runs can copy supporting files from the masked path via `source_skill_dir`, avoiding contamination from the installed copy’s original description (and Codex marker shadowing).
> 
> **Outcomes and timeouts:** Single-query runners now return string outcomes (`triggered` / `completed` / `timeout`) instead of booleans. Timeouts still count as non-triggers but are reported per query and in the summary (`timeouts`), with stderr warnings when they may skew results. Docs in `schemas.md` and `trigger_eval_boundaries.md` describe interpretation and recovery if masking is interrupted.
> 
> **Shared streaming:** Claude and Codex eval paths delegate JSON-line subprocess watching to new `trigger_probe.watch_process`, aligning timeout handling, trailing-buffer classification, and stderr capture (reducing flaky false negatives and pipe stalls).
> 
> **Eval viewer:** `generate_review.py` drops `_kill_port` (no SIGTERM on the default port); bind failures fall back to a free port only.
> 
> Tests cover masking, timeout aggregation, and the refactored probe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 705d9b6a14f0d39e1c5f0301409882e4fc175ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->