### PR TITLE
chore(skills): link skill-forge into .claude and .agents skill dirs

### DIFF
--- a/.agents/skills/skill-forge
+++ b/.agents/skills/skill-forge
@@ -1,0 +1,1 @@
+../../plugins/agent-skills/skills/skill-forge

--- a/.claude/skills/skill-forge
+++ b/.claude/skills/skill-forge
@@ -1,0 +1,1 @@
+../../plugins/agent-skills/skills/skill-forge


### PR DESCRIPTION
## 概要

`plugins/agent-skills/skills/skill-forge` を、このリポジトリでの Claude Code / Codex セッションから利用できるよう、相対symlinkで `.claude/skills/` と `.agents/skills/` に公開します。

`git-commit` や github プラグインのスキル群（`gh-issue-organizer`, `deep-research-read-me`）と同じ既存の慣習（mode 120000 の相対symlink）に従っています。

## 変更内容

- `.claude/skills/skill-forge` → `../../plugins/agent-skills/skills/skill-forge`
- `.agents/skills/skill-forge` → `../../plugins/agent-skills/skills/skill-forge`

## 関連

- #69（skill-forge トリガー評価の修正。本PRとは独立にマージ可能です）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds symlink entries; no runtime, auth, or application logic changes.
> 
> **Overview**
> **Exposes the existing `skill-forge` skill** in `plugins/agent-skills/skills/skill-forge` to local agent sessions by adding two relative symlinks: `.claude/skills/skill-forge` and `.agents/skills/skill-forge`, each targeting `../../plugins/agent-skills/skills/skill-forge`.
> 
> This matches the repo’s existing pattern for other plugin skills (e.g. `git-commit`, GitHub-related skills) so Claude Code and Codex can discover and trigger **skill-forge** without duplicating the skill content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64d5f80de2f9d2535b8c4d7eb5332c83c6267d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->