### PR TITLE
refactor(skill-forge): structural cleanups from code quality audit

### DIFF
--- a/plugins/agent-skills/skills/skill-forge/SKILL.md
+++ b/plugins/agent-skills/skills/skill-forge/SKILL.md
@@ -124,16 +124,16 @@ Generate Codex UI metadata after the target skill has stable `SKILL.md`
 frontmatter:
 
 ```bash
-uv run python scripts/generate_openai_yaml.py <skill-dir>
+uv run python -m scripts.generate_openai_yaml <skill-dir>
 ```
 
 Run validation before packaging or publishing:
 
 ```bash
-uv run python scripts/quick_validate.py <skill-dir>
-uv run python scripts/quick_validate.py <skill-dir> --platform claude
-uv run python scripts/quick_validate.py <skill-dir> --platform codex
-uv run python scripts/quick_validate.py <skill-dir> --platform codex --strict-openai-yaml
+uv run python -m scripts.quick_validate <skill-dir>
+uv run python -m scripts.quick_validate <skill-dir> --platform claude
+uv run python -m scripts.quick_validate <skill-dir> --platform codex
+uv run python -m scripts.quick_validate <skill-dir> --platform codex --strict-openai-yaml
 ```
 
 Use `--platform claude` for Claude Code-only frontmatter such as

--- a/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
+++ b/plugins/agent-skills/skills/skill-forge/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: c19979d30a89ff5b69d7a857424eee7c4216ebb74c82040f89b48afd8b5644f1
+# skill-forge-source-sha256: 5ed735b2ea51c15ab7682506369d2762d694c5290721cc5de1fb4a4398c9fad7
 interface:
   display_name: "Skill Forge"
   short_description: "Create and improve agent skills"

--- a/plugins/agent-skills/skills/skill-forge/references/openai_yaml.md
+++ b/plugins/agent-skills/skills/skill-forge/references/openai_yaml.md
@@ -13,13 +13,13 @@ Add `agents/openai.yaml` when a skill is intended for Codex users, plugins, or m
 Run this from the `skill-forge` skill directory:
 
 ```bash
-uv run python scripts/generate_openai_yaml.py <skill-dir>
+uv run python -m scripts.generate_openai_yaml <skill-dir>
 ```
 
 Override interface fields when the generated defaults are too generic:
 
 ```bash
-uv run python scripts/generate_openai_yaml.py <skill-dir> \
+uv run python -m scripts.generate_openai_yaml <skill-dir> \
   --interface display_name="PDF Toolkit" \
   --interface short_description="Create and verify PDF files" \
   --interface default_prompt="Use $pdf-toolkit to inspect this PDF."
@@ -32,7 +32,7 @@ After changing `SKILL.md`, regenerate `agents/openai.yaml`.
 Use strict validation before publishing a Codex skill:
 
 ```bash
-uv run python scripts/quick_validate.py <skill-dir> --platform codex --strict-openai-yaml
+uv run python -m scripts.quick_validate <skill-dir> --platform codex --strict-openai-yaml
 ```
 
 Strict validation checks that:

--- a/plugins/agent-skills/skills/skill-forge/scripts/aggregate_benchmark.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/aggregate_benchmark.py
@@ -44,6 +44,22 @@ from pathlib import Path
 WORKSPACE_LAYOUT_GLOB = "eval-*"
 LEGACY_LAYOUT_DIRNAME = "runs"
 
+# Config names that always act as the delta baseline, regardless of the
+# alphabetical order in which config directories are discovered.
+BASELINE_CONFIG_NAMES = {"without_skill", "old_skill", "baseline"}
+
+
+def order_configs(configs: list[str]) -> list[str]:
+    """Order configs so the primary comes first and the baseline last.
+
+    Delta is computed as first minus second, so a recognized baseline name
+    is moved to the end to keep the sign meaningful.
+    """
+    baselines = [c for c in configs if c in BASELINE_CONFIG_NAMES]
+    if len(baselines) == 1:
+        return [c for c in configs if c not in BASELINE_CONFIG_NAMES] + baselines
+    return list(configs)
+
 
 def normalize_expectations(grading: dict) -> list:
     """Return canonical graded expectations, accepting legacy assertions."""
@@ -197,7 +213,7 @@ def aggregate_results(results: dict) -> dict:
     Returns run_summary with stats for each configuration and delta.
     """
     run_summary = {}
-    configs = list(results.keys())
+    configs = order_configs(list(results.keys()))
 
     for config in configs:
         runs = results.get(config, [])
@@ -220,12 +236,15 @@ def aggregate_results(results: dict) -> dict:
             "tokens": calculate_stats(tokens)
         }
 
-    # Calculate delta between the first two configs (if two exist)
+    # Calculate delta between the primary and baseline configs (if two exist)
     if len(configs) >= 2:
-        primary = run_summary.get(configs[0], {})
-        baseline = run_summary.get(configs[1], {})
+        primary_name, baseline_name = configs[0], configs[1]
+        primary = run_summary.get(primary_name, {})
+        baseline = run_summary.get(baseline_name, {})
     else:
-        primary = run_summary.get(configs[0], {}) if configs else {}
+        primary_name = configs[0] if configs else None
+        baseline_name = None
+        primary = run_summary.get(primary_name, {}) if primary_name else {}
         baseline = {}
 
     delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
@@ -235,7 +254,9 @@ def aggregate_results(results: dict) -> dict:
     run_summary["delta"] = {
         "pass_rate": f"{delta_pass_rate:+.2f}",
         "time_seconds": f"{delta_time:+.1f}",
-        "tokens": f"{delta_tokens:+.0f}"
+        "tokens": f"{delta_tokens:+.0f}",
+        # Self-describing orientation so the sign never depends on key order
+        "comparison": f"{primary_name} - {baseline_name}" if baseline_name else (primary_name or ""),
     }
 
     return run_summary
@@ -313,6 +334,7 @@ def generate_markdown(benchmark: dict) -> str:
         f"**Model**: {metadata['executor_model']}",
         f"**Date**: {metadata['timestamp']}",
         f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        f"**Delta**: {run_summary.get('delta', {}).get('comparison', '—')}",
         "",
         "## Summary",
         "",

--- a/plugins/agent-skills/skills/skill-forge/scripts/aggregate_benchmark.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/aggregate_benchmark.py
@@ -50,14 +50,19 @@ BASELINE_CONFIG_NAMES = {"without_skill", "old_skill", "baseline"}
 
 
 def order_configs(configs: list[str]) -> list[str]:
-    """Order configs so the primary comes first and the baseline last.
+    """Order configs so the primary comes first and the baseline second.
 
     Delta is computed as first minus second, so a recognized baseline name
-    is moved to the end to keep the sign meaningful.
+    is moved into the second slot to keep the sign meaningful even when
+    more than two configurations exist.
     """
     baselines = [c for c in configs if c in BASELINE_CONFIG_NAMES]
     if len(baselines) == 1:
-        return [c for c in configs if c not in BASELINE_CONFIG_NAMES] + baselines
+        baseline = baselines[0]
+        rest = [c for c in configs if c != baseline]
+        if not rest:
+            return [baseline]
+        return [rest[0], baseline, *rest[1:]]
     return list(configs)
 
 

--- a/plugins/agent-skills/skills/skill-forge/scripts/ci/verify.sh
+++ b/plugins/agent-skills/skills/skill-forge/scripts/ci/verify.sh
@@ -22,8 +22,8 @@ uv run pytest -m "not integration"
 
 # ── スキルバリデーション ─────────────────────────────
 echo "==> Validating skill"
-uv run python scripts/quick_validate.py .
-uv run python scripts/quick_validate.py . --platform codex --strict-openai-yaml
+uv run python -m scripts.quick_validate .
+uv run python -m scripts.quick_validate . --platform codex --strict-openai-yaml
 
 echo ""
 echo "All checks passed."

--- a/plugins/agent-skills/skills/skill-forge/scripts/generate_openai_yaml.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/generate_openai_yaml.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Generate Codex agents/openai.yaml metadata for a skill."""
+"""Generate Codex agents/openai.yaml metadata for a skill.
+
+Run as a module so shared helpers resolve: `uv run python -m scripts.generate_openai_yaml`.
+"""
 
 import argparse
 import hashlib
-import re
 import sys
 from pathlib import Path
 
-import yaml
+from scripts.utils import parse_frontmatter
 
 ACRONYMS = {
     "AI",
@@ -53,20 +55,7 @@ def read_frontmatter(skill_dir: Path) -> dict:
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
         raise ValueError(f"SKILL.md not found in {skill_dir}")
-
-    content = skill_md.read_text()
-    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-    if not match:
-        raise ValueError("Invalid SKILL.md frontmatter format")
-
-    try:
-        frontmatter = yaml.safe_load(match.group(1))
-    except yaml.YAMLError as exc:
-        raise ValueError(f"Invalid YAML frontmatter: {exc}") from exc
-
-    if not isinstance(frontmatter, dict):
-        raise ValueError("Frontmatter must be a YAML dictionary")
-    return frontmatter
+    return parse_frontmatter(skill_md.read_text())
 
 
 def format_display_name(skill_name: str) -> str:

--- a/plugins/agent-skills/skills/skill-forge/scripts/generate_report.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/generate_report.py
@@ -217,11 +217,7 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
         test_total = h.get("test_total")
         description = h.get("description", "")
         train_results = h.get("train_results", [])
-        test_results = h.get("test_results", [])
-
-        # Create lookups for results by query
-        train_by_query = {r["query"]: r for r in train_results}
-        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+        test_results = h.get("test_results", []) or []
 
         # Compute aggregate correct/total runs across all retries
         def aggregate_runs(results: list[dict]) -> tuple[int, int]:
@@ -262,9 +258,10 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
                 <td class="description">{html.escape(description)}</td>
 """)
 
-        # Add result for each train query
-        for qinfo in train_queries:
-            r = train_by_query.get(qinfo["query"], {})
+        # Results keep the eval-set order across iterations, so resolve each
+        # column by position — a query-text lookup would collapse duplicates.
+        for idx in range(len(train_queries)):
+            r = train_results[idx] if idx < len(train_results) else {}
             did_pass = r.get("pass", False)
             triggers = r.get("triggers", 0)
             runs = r.get("runs", 0)
@@ -275,8 +272,8 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
             html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
 
         # Add result for each test query (with different background)
-        for qinfo in test_queries:
-            r = test_by_query.get(qinfo["query"], {})
+        for idx in range(len(test_queries)):
+            r = test_results[idx] if idx < len(test_results) else {}
             did_pass = r.get("pass", False)
             triggers = r.get("triggers", 0)
             runs = r.get("runs", 0)

--- a/plugins/agent-skills/skills/skill-forge/scripts/generate_report.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/generate_report.py
@@ -23,7 +23,7 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
     train_queries: list[dict] = []
     test_queries: list[dict] = []
     if history:
-        for r in history[0].get("train_results", history[0].get("results", [])):
+        for r in history[0].get("train_results", []):
             train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
         if history[0].get("test_results"):
             for r in history[0].get("test_results", []):
@@ -206,17 +206,17 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
     if test_queries:
         best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
     else:
-        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+        best_iter = max(history, key=lambda h: h.get("train_passed", 0)).get("iteration")
 
     # Add rows for each iteration
     for h in history:
         iteration = h.get("iteration", "?")
-        train_passed = h.get("train_passed", h.get("passed", 0))
-        train_total = h.get("train_total", h.get("total", 0))
+        train_passed = h.get("train_passed", 0)
+        train_total = h.get("train_total", 0)
         test_passed = h.get("test_passed")
         test_total = h.get("test_total")
         description = h.get("description", "")
-        train_results = h.get("train_results", h.get("results", []))
+        train_results = h.get("train_results", [])
         test_results = h.get("test_results", [])
 
         # Create lookups for results by query

--- a/plugins/agent-skills/skills/skill-forge/scripts/improve_description.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/improve_description.py
@@ -73,7 +73,7 @@ Current scores ({scores_summary}):
     if history:
         prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
         for item in history:
-            train_history = f"{item.get('train_passed', item.get('passed', 0))}/{item.get('train_total', item.get('total', 0))}"
+            train_history = f"{item.get('train_passed', 0)}/{item.get('train_total', 0)}"
             test_history = None
             if item.get("test_passed") is not None:
                 test_history = f"{item.get('test_passed')}/{item.get('test_total', '?')}"
@@ -82,9 +82,9 @@ Current scores ({scores_summary}):
                 score_line += f", test={test_history}"
             prompt += f"<attempt {score_line}>\n"
             prompt += f'Description: "{item["description"]}"\n'
-            if "results" in item:
+            if item.get("train_results"):
                 prompt += "Train results:\n"
-                for result in item["results"]:
+                for result in item["train_results"]:
                     status = "PASS" if result["pass"] else "FAIL"
                     prompt += f'  [{status}] "{result["query"][:80]}" (triggered {result["triggers"]}/{result["runs"]})\n'
             if item.get("note"):
@@ -264,10 +264,10 @@ def main():
         "description": new_description,
         "history": history + [{
             "description": current_description,
-            "passed": eval_results["summary"]["passed"],
-            "failed": eval_results["summary"]["failed"],
-            "total": eval_results["summary"]["total"],
-            "results": eval_results["results"],
+            "train_passed": eval_results["summary"]["passed"],
+            "train_failed": eval_results["summary"]["failed"],
+            "train_total": eval_results["summary"]["total"],
+            "train_results": eval_results["results"],
         }],
     }
     print(json.dumps(output, indent=2))

--- a/plugins/agent-skills/skills/skill-forge/scripts/quick_validate.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/quick_validate.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Quick validation script for skills."""
+"""Quick validation script for skills.
+
+Run as a module so shared helpers resolve: `uv run python -m scripts.quick_validate`.
+"""
 
 import argparse
 import hashlib
@@ -7,6 +10,8 @@ import sys
 import re
 import yaml
 from pathlib import Path
+
+from scripts.utils import parse_frontmatter
 
 PLATFORM_AUTO = "auto"
 PLATFORM_CLAUDE = "claude"
@@ -202,24 +207,10 @@ def validate_skill(skill_path, platform=PLATFORM_AUTO, strict_openai_yaml=False)
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
-    if not content.startswith('---'):
-        return False, "No YAML frontmatter found"
-
-    # Extract frontmatter
-    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
-    if not match:
-        return False, "Invalid frontmatter format"
-
-    frontmatter_text = match.group(1)
-
-    # Parse YAML frontmatter
     try:
-        frontmatter = yaml.safe_load(frontmatter_text)
-        if not isinstance(frontmatter, dict):
-            return False, "Frontmatter must be a YAML dictionary"
-    except yaml.YAMLError as e:
-        return False, f"Invalid YAML in frontmatter: {e}"
+        frontmatter = parse_frontmatter(skill_md.read_text())
+    except ValueError as e:
+        return False, str(e)
 
     allowed_properties = _allowed_properties(platform)
 

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
@@ -60,22 +60,20 @@ def run_eval(
     cli_type: str = CLI_CLAUDE,
     cli_command: str | None = None,
 ) -> dict:
-    """Run the full eval set and return results."""
-    results = []
-    query_outcomes: dict[str, list[str]] = {}
-    query_errors: dict[str, list[str]] = {}
-    query_items: dict[str, dict] = {}
+    """Run the full eval set and return results.
+
+    Results are keyed by eval-set position and returned in input order, so
+    duplicate query texts stay independent.
+    """
+    run_outcomes: list[list[str]] = [[] for _ in eval_set]
+    run_errors: list[list[str]] = [[] for _ in eval_set]
 
     with mask_installed_skill(cli_type, skill_name, project_root) as masked_skill_dir:
         source_skill_dir = str(masked_skill_dir) if masked_skill_dir else None
         with ProcessPoolExecutor(max_workers=num_workers) as executor:
-            future_to_info = {}
-            for item in eval_set:
-                query = item["query"]
-                query_outcomes.setdefault(query, [])
-                query_errors.setdefault(query, [])
-                query_items[query] = item
-                for run_idx in range(runs_per_query):
+            future_to_index = {}
+            for index, item in enumerate(eval_set):
+                for _ in range(runs_per_query):
                     future = executor.submit(
                         run_single_query,
                         item["query"],
@@ -88,18 +86,17 @@ def run_eval(
                         cli_command,
                         source_skill_dir,
                     )
-                    future_to_info[future] = (item, run_idx)
+                    future_to_index[future] = index
 
-            for future in as_completed(future_to_info):
-                item, _ = future_to_info[future]
-                query = item["query"]
+            for future in as_completed(future_to_index):
+                index = future_to_index[future]
                 try:
-                    query_outcomes[query].append(future.result())
+                    run_outcomes[index].append(future.result())
                 except Exception as e:
                     print(f"Error: query failed: {e}", file=sys.stderr)
-                    query_errors[query].append(str(e))
+                    run_errors[index].append(str(e))
 
-    total_errors = sum(len(errs) for errs in query_errors.values())
+    total_errors = sum(len(errs) for errs in run_errors)
     if total_errors > 0:
         print(
             f"Warning: {total_errors} query run(s) failed with errors. "
@@ -107,9 +104,7 @@ def run_eval(
             file=sys.stderr,
         )
 
-    total_timeouts = sum(
-        outcomes.count(TIMEOUT) for outcomes in query_outcomes.values()
-    )
+    total_timeouts = sum(outcomes.count(TIMEOUT) for outcomes in run_outcomes)
     if total_timeouts > 0:
         print(
             f"Warning: {total_timeouts} run(s) hit the {timeout}s timeout before "
@@ -118,9 +113,9 @@ def run_eval(
             file=sys.stderr,
         )
 
-    for query, outcomes in query_outcomes.items():
-        item = query_items[query]
-        errors = query_errors.get(query, [])
+    results = []
+    for item, outcomes, errors in zip(eval_set, run_outcomes, run_errors):
+        query = item["query"]
         effective_runs = len(outcomes)
         triggers = outcomes.count(TRIGGERED)
         timeouts = outcomes.count(TIMEOUT)

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_loop.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_loop.py
@@ -103,10 +103,9 @@ def run_loop(
         )
         eval_elapsed = time.time() - t0
 
-        # Split results back into train/test by matching queries
-        train_queries_set = {q["query"] for q in train_set}
-        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
-        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+        # run_eval returns results in input order, so slice train/test back out
+        train_result_list = all_results["results"][:len(train_set)]
+        test_result_list = all_results["results"][len(train_set):]
 
         train_passed = sum(1 for r in train_result_list if r["pass"])
         train_total = len(train_result_list)
@@ -133,11 +132,6 @@ def run_loop(
             "test_failed": test_summary["failed"] if test_summary else None,
             "test_total": test_summary["total"] if test_summary else None,
             "test_results": test_results["results"] if test_results else None,
-            # For backward compat with report generator
-            "passed": train_summary["passed"],
-            "failed": train_summary["failed"],
-            "total": train_summary["total"],
-            "results": train_results["results"],
         })
 
         # Write live report if path provided

--- a/plugins/agent-skills/skills/skill-forge/scripts/utils.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/utils.py
@@ -168,6 +168,7 @@ def parse_frontmatter(content: str) -> dict:
 
     Raises ValueError with a human-readable reason on malformed frontmatter.
     """
+    content = content.replace("\r\n", "\n")
     if not content.startswith("---"):
         raise ValueError("SKILL.md missing frontmatter (no opening ---)")
     match = FRONTMATTER_PATTERN.match(content)

--- a/plugins/agent-skills/skills/skill-forge/scripts/utils.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/utils.py
@@ -1,13 +1,18 @@
 """Shared utilities for skill-forge scripts."""
 
 import os
+import re
 import shutil
 import sys
 from contextlib import contextmanager
 from pathlib import Path
 
+import yaml
+
 CLI_CLAUDE = "claude"
 CLI_CODEX = "codex"
+
+FRONTMATTER_PATTERN = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 
 
 def get_default_cli_home_name(cli_type: str) -> str:
@@ -158,44 +163,33 @@ def mask_installed_skill(cli_type: str, skill_name: str, project_root: Path):
             pass
 
 
-def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
-    """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
-    lines = content.split("\n")
+def parse_frontmatter(content: str) -> dict:
+    """Parse SKILL.md YAML frontmatter into a dict.
 
-    if lines[0].strip() != "---":
+    Raises ValueError with a human-readable reason on malformed frontmatter.
+    """
+    if not content.startswith("---"):
         raise ValueError("SKILL.md missing frontmatter (no opening ---)")
-
-    end_idx = None
-    for i, line in enumerate(lines[1:], start=1):
-        if line.strip() == "---":
-            end_idx = i
-            break
-
-    if end_idx is None:
+    match = FRONTMATTER_PATTERN.match(content)
+    if not match:
         raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in frontmatter: {exc}") from exc
+    if not isinstance(frontmatter, dict):
+        raise ValueError("Frontmatter must be a YAML dictionary")
+    return frontmatter
 
-    name = ""
-    description = ""
-    frontmatter_lines = lines[1:end_idx]
-    i = 0
-    while i < len(frontmatter_lines):
-        line = frontmatter_lines[i]
-        if line.startswith("name:"):
-            name = line[len("name:"):].strip().strip('"').strip("'")
-        elif line.startswith("description:"):
-            value = line[len("description:"):].strip()
-            # Handle YAML multiline indicators (>, |, >-, |-)
-            if value in (">", "|", ">-", "|-"):
-                continuation_lines: list[str] = []
-                i += 1
-                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
-                    continuation_lines.append(frontmatter_lines[i].strip())
-                    i += 1
-                description = " ".join(continuation_lines)
-                continue
-            else:
-                description = value.strip('"').strip("'")
-        i += 1
 
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content).
+
+    The description is whitespace-normalized to a single line, since callers
+    embed it in eval prompts and generated frontmatter.
+    """
+    content = (skill_path / "SKILL.md").read_text()
+    frontmatter = parse_frontmatter(content)
+    name = str(frontmatter.get("name") or "").strip()
+    description = " ".join(str(frontmatter.get("description") or "").split())
     return name, description, content

--- a/plugins/agent-skills/skills/skill-forge/tests/test_aggregate_benchmark.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_aggregate_benchmark.py
@@ -1,5 +1,7 @@
 """Tests for scripts.aggregate_benchmark module."""
 
+import json
+
 import pytest
 
 from scripts.aggregate_benchmark import generate_benchmark, load_run_results, normalize_expectations
@@ -50,3 +52,33 @@ class TestLoadRunResults:
         }
 
         assert normalize_expectations(grading) == [{"text": "canonical", "passed": True}]
+
+
+class TestDeltaOrientation:
+    def _write_grading(self, tmp_path, config, pass_rate):
+        run_dir = tmp_path / "eval-0" / config / "run-1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "grading.json").write_text(
+            json.dumps({"summary": {"pass_rate": pass_rate, "passed": 1, "failed": 0, "total": 1}})
+        )
+
+    def test_known_baseline_name_is_moved_to_baseline_position(self, tmp_path):
+        # Alphabetical scan order would make "baseline" the primary and flip the sign
+        self._write_grading(tmp_path, "baseline", 0.5)
+        self._write_grading(tmp_path, "skill", 1.0)
+
+        benchmark = generate_benchmark(tmp_path, skill_name="test-skill")
+        delta = benchmark["run_summary"]["delta"]
+
+        assert delta["comparison"] == "skill - baseline"
+        assert delta["pass_rate"] == "+0.50"
+
+    def test_with_without_skill_orientation_is_stable(self, tmp_path):
+        self._write_grading(tmp_path, "with_skill", 1.0)
+        self._write_grading(tmp_path, "without_skill", 0.5)
+
+        benchmark = generate_benchmark(tmp_path, skill_name="test-skill")
+        delta = benchmark["run_summary"]["delta"]
+
+        assert delta["comparison"] == "with_skill - without_skill"
+        assert delta["pass_rate"] == "+0.50"

--- a/plugins/agent-skills/skills/skill-forge/tests/test_aggregate_benchmark.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_aggregate_benchmark.py
@@ -82,3 +82,16 @@ class TestDeltaOrientation:
 
         assert delta["comparison"] == "with_skill - without_skill"
         assert delta["pass_rate"] == "+0.50"
+
+    def test_baseline_takes_second_slot_with_more_than_two_configs(self, tmp_path):
+        # Alphabetical scan order is alt, baseline, skill; the delta must
+        # still compare a primary against the recognized baseline.
+        self._write_grading(tmp_path, "alt", 0.8)
+        self._write_grading(tmp_path, "baseline", 0.5)
+        self._write_grading(tmp_path, "skill", 1.0)
+
+        benchmark = generate_benchmark(tmp_path, skill_name="test-skill")
+        delta = benchmark["run_summary"]["delta"]
+
+        assert delta["comparison"] == "alt - baseline"
+        assert delta["pass_rate"] == "+0.30"

--- a/plugins/agent-skills/skills/skill-forge/tests/test_generate_report.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_generate_report.py
@@ -1,0 +1,62 @@
+"""Tests for scripts.generate_report module."""
+
+from scripts.generate_report import generate_html
+
+
+def make_history_entry(train_results, test_results=None):
+    passed = sum(1 for r in train_results if r["pass"])
+    return {
+        "iteration": 1,
+        "description": "desc",
+        "train_passed": passed,
+        "train_failed": len(train_results) - passed,
+        "train_total": len(train_results),
+        "train_results": train_results,
+        "test_passed": None,
+        "test_failed": None,
+        "test_total": None,
+        "test_results": test_results,
+    }
+
+
+class TestGenerateHtml:
+    def test_duplicate_query_columns_keep_their_own_results(self):
+        train_results = [
+            {"query": "same query", "should_trigger": True, "pass": True, "triggers": 1, "runs": 1},
+            {"query": "same query", "should_trigger": False, "pass": False, "triggers": 1, "runs": 1},
+        ]
+        data = {
+            "history": [make_history_entry(train_results)],
+            "holdout": 0,
+            "original_description": "orig",
+            "best_description": "best",
+            "best_score": "1/2",
+            "iterations_run": 1,
+            "train_size": 2,
+            "test_size": 0,
+        }
+
+        html = generate_html(data)
+
+        # A query-text lookup would render both cells from the same entry
+        assert html.count("\u2713") == 1
+        assert html.count("\u2717") == 1
+
+    def test_none_test_results_render_without_error(self):
+        train_results = [
+            {"query": "q", "should_trigger": True, "pass": True, "triggers": 1, "runs": 1},
+        ]
+        data = {
+            "history": [make_history_entry(train_results, test_results=None)],
+            "holdout": 0,
+            "original_description": "orig",
+            "best_description": "best",
+            "best_score": "1/1",
+            "iterations_run": 1,
+            "train_size": 1,
+            "test_size": 0,
+        }
+
+        html = generate_html(data)
+
+        assert "\u2713" in html

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
@@ -759,6 +759,32 @@ class TestRunEval:
         assert result["results"][0]["pass"] is False
         assert result["results"][0]["error_count"] == 1
 
+    def test_duplicate_queries_stay_independent_and_ordered(self):
+        eval_set = [
+            {"query": "same query", "should_trigger": True},
+            {"query": "same query", "should_trigger": False},
+        ]
+        outcomes = iter(["triggered", "completed"])
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", ThreadPoolExecutor):
+            with patch("scripts.run_eval.run_single_query", side_effect=lambda *a, **k: next(outcomes)):
+                result = run_eval(
+                    eval_set=eval_set,
+                    skill_name="test",
+                    description="desc",
+                    num_workers=1,
+                    timeout=10,
+                    project_root=Path("/tmp"),
+                    runs_per_query=1,
+                    trigger_threshold=0.5,
+                    cli_type=CLI_CLAUDE,
+                )
+
+        assert [r["should_trigger"] for r in result["results"]] == [True, False]
+        assert result["results"][0]["triggers"] == 1
+        assert result["results"][1]["triggers"] == 0
+        assert all(r["pass"] for r in result["results"])
+
     def test_query_with_zero_attempted_runs_is_marked_not_run(self):
         eval_set = [{"query": "do not trigger", "should_trigger": False}]
 

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_loop.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_loop.py
@@ -60,3 +60,54 @@ class TestRunLoop:
         assert result["best_description"] == "new desc"
         assert mock_improve.call_args.kwargs["cli_type"] == CLI_CODEX
         assert mock_improve.call_args.kwargs["cli_command"] == "/custom/codex"
+
+    def test_holdout_split_slices_results_in_input_order(self):
+        eval_set = [
+            {"query": f"q{i}", "should_trigger": i % 2 == 0} for i in range(6)
+        ]
+
+        def fake_run_eval(**kwargs):
+            results = [
+                {
+                    "query": item["query"],
+                    "should_trigger": item["should_trigger"],
+                    "trigger_rate": 1.0 if item["should_trigger"] else 0.0,
+                    "triggers": 1 if item["should_trigger"] else 0,
+                    "runs": 1,
+                    "pass": True,
+                }
+                for item in kwargs["eval_set"]
+            ]
+            return {
+                "results": results,
+                "summary": {"passed": len(results), "failed": 0, "total": len(results)},
+            }
+
+        with patch("scripts.run_loop.find_project_root", return_value=Path("/tmp/project")):
+            with patch("scripts.run_loop.parse_skill_md", return_value=("skill-forge", "old desc", "# skill")):
+                with patch("scripts.run_loop.run_eval", side_effect=fake_run_eval):
+                    result = run_loop(
+                        eval_set=eval_set,
+                        skill_path=Path("/tmp/skill-forge"),
+                        description_override=None,
+                        num_workers=1,
+                        timeout=10,
+                        max_iterations=1,
+                        runs_per_query=1,
+                        trigger_threshold=0.5,
+                        holdout=0.4,
+                        model="test-model",
+                        verbose=False,
+                    )
+
+        assert result["train_size"] + result["test_size"] == len(eval_set)
+        entry = result["history"][0]
+        assert entry["train_total"] == result["train_size"]
+        assert entry["test_total"] == result["test_size"]
+        train_queries = {r["query"] for r in entry["train_results"]}
+        test_queries = {r["query"] for r in entry["test_results"]}
+        assert train_queries | test_queries == {f"q{i}" for i in range(6)}
+        assert train_queries & test_queries == set()
+        # Legacy aliases are gone
+        assert "passed" not in entry
+        assert "results" not in entry

--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_docs.py
@@ -67,7 +67,7 @@ class TestSkillDocs:
         reference = (SKILL_DIR / "references" / "openai_yaml.md").read_text()
 
         assert "references/openai_yaml.md" in skill_md
-        assert "scripts/generate_openai_yaml.py" in skill_md
+        assert "scripts.generate_openai_yaml" in skill_md
         assert "--strict-openai-yaml" in skill_md
         assert "display_name" in reference
         assert "short_description" in reference

--- a/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
@@ -307,6 +307,19 @@ class TestParseSkillMd:
         with pytest.raises(ValueError, match="YAML dictionary"):
             parse_skill_md(tmp_path)
 
+    def test_crlf_line_endings_are_accepted(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_bytes(
+            b"---\r\n"
+            b"name: crlf-skill\r\n"
+            b"description: A skill saved with Windows line endings\r\n"
+            b"---\r\n\r\n"
+            b"# Body\r\n"
+        )
+        name, desc, _ = parse_skill_md(tmp_path)
+        assert name == "crlf-skill"
+        assert desc == "A skill saved with Windows line endings"
+
 
 class TestProjectSkillInstallDir:
     def test_claude_uses_project_claude_skills(self, tmp_path):

--- a/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_utils.py
@@ -290,6 +290,23 @@ class TestParseSkillMd:
         with pytest.raises(ValueError, match="no closing"):
             parse_skill_md(tmp_path)
 
+    def test_invalid_yaml_raises(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "---\n"
+            "name: bad-skill\n"
+            "description: broken: because: of: colons\n"
+            "---\n"
+        )
+        with pytest.raises(ValueError, match="Invalid YAML"):
+            parse_skill_md(tmp_path)
+
+    def test_non_dict_frontmatter_raises(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("---\n- just\n- a list\n---\n")
+        with pytest.raises(ValueError, match="YAML dictionary"):
+            parse_skill_md(tmp_path)
+
 
 class TestProjectSkillInstallDir:
     def test_claude_uses_project_claude_skills(self, tmp_path):


### PR DESCRIPTION
## 概要

skill-forge 監査（#69 の続き）で報告した構造的問題4件の修正です。挙動を変えるのは重複クエリとdelta方向の2点のみで、他は等価な構造整理です。

### 1. frontmatterパーサーの3重実装を統一（`43e1b34`）

`utils.parse_skill_md`（手書き行パーサー）、`quick_validate`、`generate_openai_yaml`（regex+yamlのコピー2つ）がそれぞれ独自にfrontmatterを解釈していました。`utils.parse_frontmatter` に一本化し、ブロックスカラー・クォート・エラー文言のセマンティクスを1箇所に集約しました。

- 共有ヘルパーのimportに伴い、`quick_validate` / `generate_openai_yaml` の起動形式をモジュール形式（`python -m scripts.quick_validate`）に変更（`run_loop`/`package_skill` と同形式に統一）。SKILL.md・`references/openai_yaml.md`・`verify.sh` を更新し、`agents/openai.yaml` を再生成（interface値は既存のものを維持）
- 手書きパーサーと異なり、不正なYAML frontmatterは明示的に `ValueError` になります（`quick_validate` は従来からYAML妥当性を要求していたため、実質的な互換性影響はなし）

### 2. eval結果を位置キーに変更し、重複クエリの無音マージを解消（`14efdde`）

`run_eval` がクエリ文字列で結果をマージしていたため、eval set内の重複クエリが1エントリに潰れ、`run_loop` のクエリ文字列によるtrain/test再分割でtest結果がtrainに漏れる可能性がありました。結果を入力順の位置キーで管理し、`run_loop` は長さでスライスして分割するようにしました。

### 3. run_loop履歴のlegacyキーを削除（`14efdde`）

history要素が `train_*` と legacy `passed/failed/total/results` の二重形状を持ち、`improve_description`・`generate_report` にフォールバック読み取りが散在していました。書き手・読み手とも `train_*` 形状に一本化しました（`improve_description` CLIの履歴出力形状も統一）。

### 4. benchmark deltaの方向を明示化（`efed664`）

delta が「最初の2つのconfig」＝ディレクトリのアルファベット順に依存し、`baseline`/`skill` のような命名では符号が黙って反転していました。既知のbaseline名（`without_skill`/`old_skill`/`baseline`）をbaseline位置に固定し、`delta.comparison`（例: `"with_skill - without_skill"`）で方向を自己記述化。`benchmark.md` にも表示します。

## テスト

- `bash scripts/ci/verify.sh`: ユニットテスト 125 件（+6件追加）パス + スキルバリデーション（auto / codex strict）通過
- 追加テスト: 不正YAML・非dict frontmatter / 重複クエリの独立性と順序 / holdout分割のスライス整合とlegacyキー不在 / delta方向（`baseline`/`skill` と `with_skill`/`without_skill`）

## 関連

- 監査由来の修正第1弾: #69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trigger-eval aggregation and benchmark delta semantics (user-visible for skill optimization), but scope is confined to skill-forge tooling with added regression tests.
> 
> **Overview**
> **Structural cleanup** in skill-forge after a code-quality audit: shared **`parse_frontmatter`** in `utils` replaces three separate SKILL.md frontmatter parsers; **`quick_validate`** and **`generate_openai_yaml`** now use it and are invoked as **`python -m scripts.*`** (docs, `verify.sh`, and `openai.yaml` source hash updated).
> 
> **Behavior fixes:** **`run_eval`** keeps one result per eval-set **index** (duplicate query text no longer merges); **`run_loop`** splits train/test by **slicing** ordered results, and history drops legacy **`passed`/`results`** keys in favor of **`train_*` only**. **`aggregate_benchmark`** pins known baseline config names (`without_skill`, `old_skill`, `baseline`) so delta sign is stable and adds **`delta.comparison`** plus a **Delta** line in **`benchmark.md`**. **`generate_report`** maps HTML columns by **position**, not query string.
> 
> New unit tests cover delta orientation, duplicate queries, holdout slicing, frontmatter edge cases, and report HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f772e5861fdc205568897275b3db51d534eb92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->