### PR TITLE
fix(skill-forge): count trigger outcomes in SKILL.md integration test

### DIFF
--- a/plugins/agent-skills/skills/skill-forge/tests/test_skill_md.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_skill_md.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from scripts.run_eval import run_single_query
+from scripts.trigger_probe import TRIGGERED
 from scripts.utils import CLI_CLAUDE, parse_skill_md
 
 # ── 定数 ──────────────────────────────────────────────────────────────────────
@@ -88,7 +89,7 @@ def _trigger_rate(query: str, skill_info: tuple, project_root: str) -> float:
         )
         for _ in range(RUNS_PER_QUERY)
     ]
-    return sum(results) / len(results)
+    return sum(1 for r in results if r == TRIGGERED) / len(results)
 
 
 # ── テスト ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

#71 で `run_single_query` の戻り値をbool → outcome文字列（`triggered`/`completed`/`timeout`）に変更した際、統合テスト `tests/test_skill_md.py` の `sum(results)` が未移行のまま残っていました（文字列のsumで `TypeError`）。統合テストはCI・Claude Codeセッション内の双方でスキップされるため、ユニットスイートでは検出できませんでした。

`TRIGGERED` outcomeを明示的にカウントするよう修正しました。

## 検証（実CLIでのトリガーeval）

修正確認を兼ねて、実 claude CLI に対するフルevalを実施しました（16クエリ × 3run、並列8、`run_eval` 経由）:

- **15/16 パス**（errors 0）
- should_not_trigger 8クエリ: 全て 0/3 で正しく非トリガー（precision 100%）
- should_trigger 8クエリ: 7クエリパス。1クエリのみ 1/3 で閾値未達（「I made a skill a while back but the outputs aren't great...」— 間接的な言い回しのrecall境界ケース）
- #69 で導入した同名スキルのマスク機構が実地で作動（`.claude/skills/skill-forge` の退避と自動復元、残骸なし）を確認
- timeout 1件は should_not_trigger クエリの応答長超過で、非トリガー集計として想定通り

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to trigger-rate aggregation; no production or eval script behavior changes.
> 
> **Overview**
> Fixes **`_trigger_rate`** in the SKILL.md integration test so it matches **`run_single_query`**’s string outcomes after #71.
> 
> **`_trigger_rate`** no longer uses **`sum(results)`** (which raised **`TypeError`** on outcome strings). It imports **`TRIGGERED`** from **`trigger_probe`** and computes the rate as the fraction of runs where the outcome equals **`TRIGGERED`**, consistent with **`run_eval`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a3f6cc993da4e8b08077949f2e019e3194d0611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->