### PR TITLE
fix(skill-forge): serialize codex trigger eval runs

### DIFF
--- a/plugins/agent-skills/skills/skill-forge/references/trigger_eval_boundaries.md
+++ b/plugins/agent-skills/skills/skill-forge/references/trigger_eval_boundaries.md
@@ -87,6 +87,16 @@ The Codex path creates a temporary repository skill under `.agents/skills/<skill
 
 It runs `codex exec --json -s read-only -C <project-root> <query>`.
 
+Codex runs execute serially regardless of `--num-workers`: all runs share the
+repository `.agents/skills/`, so concurrent temp skills carry the same visible
+name and a run may read another run's marker copy. Measured on a real batch,
+8-way parallelism dropped the positive trigger rate from ~50% to ~4%.
+
+Codex detection also needs the full response: the marker only becomes visible
+in a completed `agent_message`, so a triggering run typically takes 1-3
+minutes. Use `--timeout 240` or higher; the 30s default is claude-oriented and
+would count almost every Codex run as a timeout non-trigger.
+
 The detector treats the skill as triggered only when:
 
 - `type` is `item.completed` or `item.updated`

--- a/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/scripts/run_eval.py
@@ -65,6 +65,18 @@ def run_eval(
     Results are keyed by eval-set position and returned in input order, so
     duplicate query texts stay independent.
     """
+    if cli_type == CLI_CODEX and num_workers > 1:
+        # Codex discovers repo skills from the shared .agents/skills/, so
+        # concurrent runs would see each other's same-named temp skills and
+        # read the wrong marker. Measured: parallel runs drop the trigger
+        # rate to roughly 1/num_workers of the serial value.
+        print(
+            "Note: Codex trigger evals run serially — concurrent runs share "
+            ".agents/skills/ and contaminate each other's measurements.",
+            file=sys.stderr,
+        )
+        num_workers = 1
+
     run_outcomes: list[list[str]] = [[] for _ in eval_set]
     run_errors: list[list[str]] = [[] for _ in eval_set]
 

--- a/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
+++ b/plugins/agent-skills/skills/skill-forge/tests/test_run_eval.py
@@ -987,6 +987,56 @@ class TestTemporarySkillNames:
         assert not observed["claude_home"].exists()
 
 
+class TestCodexSerialization:
+    def test_codex_eval_forces_single_worker(self):
+        eval_set = [{"query": "q", "should_trigger": False}]
+        captured = {}
+
+        class CapturingExecutor(ThreadPoolExecutor):
+            def __init__(self, max_workers=None, **kwargs):
+                captured["max_workers"] = max_workers
+                super().__init__(max_workers=max_workers, **kwargs)
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", CapturingExecutor):
+            with patch("scripts.run_eval.run_single_query", return_value="completed"):
+                run_eval(
+                    eval_set=eval_set,
+                    skill_name="test",
+                    description="desc",
+                    num_workers=8,
+                    timeout=10,
+                    project_root=Path("/tmp"),
+                    runs_per_query=1,
+                    cli_type=CLI_CODEX,
+                )
+
+        assert captured["max_workers"] == 1
+
+    def test_claude_eval_keeps_requested_workers(self):
+        eval_set = [{"query": "q", "should_trigger": False}]
+        captured = {}
+
+        class CapturingExecutor(ThreadPoolExecutor):
+            def __init__(self, max_workers=None, **kwargs):
+                captured["max_workers"] = max_workers
+                super().__init__(max_workers=max_workers, **kwargs)
+
+        with patch("scripts.run_eval.ProcessPoolExecutor", CapturingExecutor):
+            with patch("scripts.run_eval.run_single_query", return_value="completed"):
+                run_eval(
+                    eval_set=eval_set,
+                    skill_name="test",
+                    description="desc",
+                    num_workers=8,
+                    timeout=10,
+                    project_root=Path("/tmp"),
+                    runs_per_query=1,
+                    cli_type=CLI_CLAUDE,
+                )
+
+        assert captured["max_workers"] == 8
+
+
 class TestTimeoutOutcome:
     def test_claude_timeout_returns_timeout_outcome(self, tmp_path):
         project_root = tmp_path / "project"


### PR DESCRIPTION
## 概要

改善提案1（codexパスの実CLI検証）を実施したところ、**並列実行時の測定汚染バグ**を発見しました。本PRはその修正です。

## 問題

codexはリポジトリ共有の `.agents/skills/` からスキルを発見するため、並列ワーカーが作る一時スキル（ディレクトリ名は一意だが frontmatter `name` は同一）が互いに見えてしまい、各runが自分のマーカー入りコピーを読む確率は約 1/num_workers になります。

実 codex CLI（0.142.5）での測定値:

| 実行条件 | ポジティブクエリのtrigger率 |
|---|---|
| 並列8ワーカー | **1/24 (4%)** — 汚染により測定不能 |
| 直列 | **4/8 (50%)** — 12倍改善 |

（参考: claude側は各runが専用 `CLAUDE_CONFIG_DIR` を持つため並列でも汚染なし。同一evalセットで 15/16 パス）

## 修正

- `run_eval` は `cli_type == codex` のとき `num_workers` を1に強制（stderr告知つき）
- `references/trigger_eval_boundaries.md` に直列化の理由と、codex検出は応答完了が必要なため `--timeout 240` 以上を推奨する旨を追記
- 直列化の単体テスト2件を追加（codexで1に強制 / claudeは指定値を維持）

## テスト

- ユニットテスト 131件パス、`scripts/ci/verify.sh` 全通過
- 決定版のフル直列codex eval（16クエリ×3run）を実行中。完了次第、結果をこのPRにコメントします

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to skill-forge eval orchestration and documentation; behavior change only affects Codex eval parallelism, not production agent paths.
> 
> **Overview**
> Fixes **measurement contamination** when Codex trigger evals run with `--num-workers` &gt; 1: parallel runs share repo `.agents/skills/`, so temp skills with the same visible name can cross-read markers and collapse positive trigger rates.
> 
> **`run_eval`** now forces **`num_workers = 1`** when `cli_type` is Codex (with a stderr note) while Claude keeps the requested worker count. **`trigger_eval_boundaries.md`** documents why Codex must run serially and recommends **`--timeout 240`** or higher because marker detection needs a completed `agent_message`. **Tests** assert Codex uses one worker and Claude still honors eight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b1ea1420dbb8127b364dff7dbde21a2aed00975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->