### PR TITLE
GitHubプラグインにPRワークフロースキルを登録

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,7 +24,9 @@
       "category": "development",
       "strict": true,
       "skills": [
-        "./skills/gh-issue-organizer"
+        "./skills/gh-issue-organizer",
+        "./skills/gh-pr-converge",
+        "./skills/gh-pr-review-follow-up"
       ]
     },
     {


### PR DESCRIPTION
## 概要

- Claude Code用マーケットプレイスのGitHubプラグインに gh-pr-converge を登録しました。
- 同じく gh-pr-review-follow-up を登録しました。

## 背景

PR #83でスキル本体とシンボリックリンクを追加しましたが、.claude-plugin/marketplace.json のskills一覧への登録が漏れていました。そのためClaude Codeのマーケットプレイス経由では新しいスキルが公開対象に含まれませんでした。

## 影響

GitHubプラグインをインストールしたClaude Code環境から、追加済みの2つのPRワークフロースキルを検出できるようになります。

## 検証

- Claudeプラグインマニフェスト検証
- 登録した全スキルパスのSKILL.md解決確認
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON manifest edit with no application code or security-sensitive behavior.
> 
> **Overview**
> **Registers two PR workflow skills** in `.claude-plugin/marketplace.json` under the GitHub plugin: `gh-pr-converge` and `gh-pr-review-follow-up`. The skill files were already present; only the marketplace `skills` list was missing entries, so installs via the Claude Code marketplace would not expose them.
> 
> No runtime or skill logic changes—manifest-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8777381979c50a0155b64fc6d52c718ad66db436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->