### PR TITLE
Codexマーケットプレイスとプラグインマニフェストを追加

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,68 @@
+{
+  "name": "ai-tools",
+  "interface": {
+    "displayName": "AI Tools"
+  },
+  "plugins": [
+    {
+      "name": "git",
+      "source": {
+        "source": "local",
+        "path": "./plugins/git"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "github",
+      "source": {
+        "source": "local",
+        "path": "./plugins/github"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "agent-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/agent-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "takt",
+      "source": {
+        "source": "local",
+        "path": "./plugins/takt"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "software-design",
+      "source": {
+        "source": "local",
+        "path": "./plugins/software-design"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/plugins/agent-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-skills/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "agent-skills",
+  "version": "0.1.0",
+  "description": "Agent skill authoring, validation, evaluation, and improvement workflows.",
+  "author": {
+    "name": "Junichi Kato",
+    "email": "j5ik2o@gmail.com"
+  },
+  "repository": "https://github.com/j5ik2o/ai-tools",
+  "license": "MIT OR Apache-2.0",
+  "keywords": [
+    "agent-skills",
+    "skill-authoring",
+    "evaluation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agent Skills",
+    "shortDescription": "Create and improve reusable agent skills",
+    "longDescription": "Agent skill workflows for authoring, validating, evaluating, and improving reusable skills for Claude Code and Codex.",
+    "developerName": "Junichi Kato",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use $skill-forge to create or improve this skill."
+    ]
+  }
+}

--- a/plugins/software-design/.codex-plugin/plugin.json
+++ b/plugins/software-design/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "software-design",
+  "version": "0.1.0",
+  "description": "Software design skills for domain modeling, architecture, error handling, package design, and refactoring.",
+  "author": {
+    "name": "Junichi Kato",
+    "email": "j5ik2o@gmail.com"
+  },
+  "repository": "https://github.com/j5ik2o/ai-tools",
+  "license": "MIT OR Apache-2.0",
+  "keywords": [
+    "software-design",
+    "domain-driven-design",
+    "architecture",
+    "refactoring"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Software Design",
+    "shortDescription": "Design maintainable software and domain models",
+    "longDescription": "Software design skills for domain-driven design, clean architecture, error handling, package design, and maintainable refactoring.",
+    "developerName": "Junichi Kato",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use $ddd-aggregate-design to design this aggregate.",
+      "Use $clean-architecture to review this architecture.",
+      "Use $error-handling to improve this error design."
+    ]
+  }
+}

--- a/plugins/takt/.codex-plugin/plugin.json
+++ b/plugins/takt/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "takt",
+  "version": "0.1.0",
+  "description": "TAKT workflow engine skills for multi-agent orchestration, analysis, authoring, and optimization.",
+  "author": {
+    "name": "Junichi Kato",
+    "email": "j5ik2o@gmail.com"
+  },
+  "repository": "https://github.com/j5ik2o/ai-tools",
+  "license": "MIT OR Apache-2.0",
+  "keywords": [
+    "takt",
+    "workflow",
+    "multi-agent"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "TAKT",
+    "shortDescription": "Build and optimize TAKT workflows",
+    "longDescription": "TAKT workflow engine skills for creating, analyzing, validating, and optimizing multi-agent workflow definitions and facets.",
+    "developerName": "Junichi Kato",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use $takt-workflow-builder to create a TAKT workflow.",
+      "Use $takt-analyzer to analyze this TAKT workflow.",
+      "Use $takt-optimizer to optimize this TAKT workflow."
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

既存のプラグイン名を変更せず、リポジトリをCodexマーケットプレイスとして利用できる構成を追加します。

## 変更内容

- `.agents/plugins/marketplace.json`を追加し、既存の5プラグインを登録
- `agent-skills`へ`.codex-plugin/plugin.json`を追加
- `takt`へ`.codex-plugin/plugin.json`を追加
- `software-design`へ`.codex-plugin/plugin.json`を追加
- 既存の`git`・`github`の名前とCodexマニフェストは変更なし

## 影響

Codex CLIまたはCodexアプリから`ai-tools`マーケットプレイスを登録し、各プラグインを個別にインストールできるようになります。Claude Code向けの既存マーケットプレイス構成には影響しません。

## 検証

- `plugin-creator`の`validate_plugin.py`で5プラグインを検証
- `npm run validate:codex-plugins`
- `claude plugin validate .`
- Codex CLIへ`ai-tools`マーケットプレイスを登録し、5プラグインの解決を確認
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only additions for marketplace and plugin metadata; no changes to application logic, auth flows, or existing git/github manifests.
> 
> **Overview**
> Adds **Codex marketplace** wiring so the `ai-tools` repo can be registered in Codex CLI/app and its plugins installed individually, without renaming existing plugins or changing the Claude Code marketplace layout.
> 
> Introduces `.agents/plugins/marketplace.json`, listing five local plugins (`git`, `github`, `agent-skills`, `takt`, `software-design`) with `AVAILABLE` install policy and `ON_INSTALL` authentication. Adds new `.codex-plugin/plugin.json` manifests for **agent-skills**, **takt**, and **software-design** (metadata, `skills` paths, interface copy, and default prompts); **git** and **github** Codex manifests are left as-is per the PR scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8da73415b3e875b9e5decf31c91251ed12b2488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->