### PR TITLE
Codex Pluginのインストール方法をREADMEに追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,11 +2,12 @@
 
 [English](README.md)
 
-Claude Code と、Codex のようなスキルディレクトリベース CLI 向けに AI エージェントスキルを配布するマーケットプレイス用リポジトリです。
+Claude Code と Codex 向けに、AI エージェントスキルとプラグインを配布するマーケットプレイス用リポジトリです。
 
 ## Highlights
 
 - `.claude-plugin/marketplace.json` から複数の plugin を公開
+- `.agents/plugins/marketplace.json` から Codex plugin を公開
 - `marketplace.yml` と生成済み `marketplace.json` で APM marketplace manifest を提供
 - `agent-skills`, `takt`, `software-design` などのスキルコレクションを収録
 - `skills/` に直接参照用のシンボリックリンクを保持
@@ -20,6 +21,25 @@ Claude Code と、Codex のようなスキルディレクトリベース CLI 向
 /plugin install agent-skills@ai-tools
 /plugin install takt@ai-tools
 /plugin install software-design@ai-tools
+```
+
+### Codex Plugin
+
+このリポジトリを Codex plugin marketplace として登録し、必要なプラグインをインストールします。
+
+```shell
+codex plugin marketplace add j5ik2o/ai-tools --ref main
+codex plugin add git@ai-tools
+codex plugin add github@ai-tools
+codex plugin add agent-skills@ai-tools
+codex plugin add takt@ai-tools
+codex plugin add software-design@ai-tools
+```
+
+インストール結果を確認したら、新しい Codex タスクを開いてプラグインを読み込みます。
+
+```shell
+codex plugin list
 ```
 
 ### Agent Package Manager

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [日本語](README.ja.md)
 
-A marketplace repository for distributing AI agent skills for Claude Code and skill-directory-based CLIs such as Codex.
+A marketplace repository for distributing AI agent skills and plugins for Claude Code and Codex.
 
 ## Highlights
 
 - Publishes multiple plugins through `.claude-plugin/marketplace.json`
+- Publishes Codex plugins through `.agents/plugins/marketplace.json`
 - Provides an APM marketplace manifest through `marketplace.yml` and generated `marketplace.json`
 - Includes installable skill collections such as `agent-skills`, `takt`, and `software-design`
 - Keeps `skills/`, `.agents/skills/`, and `.claude/skills/` links for tools that consume plain skill directories directly
@@ -22,6 +23,25 @@ A marketplace repository for distributing AI agent skills for Claude Code and sk
 /plugin install agent-skills@ai-tools
 /plugin install takt@ai-tools
 /plugin install software-design@ai-tools
+```
+
+### Codex Plugin
+
+Register this repository as a Codex plugin marketplace, then install the plugins you need:
+
+```shell
+codex plugin marketplace add j5ik2o/ai-tools --ref main
+codex plugin add git@ai-tools
+codex plugin add github@ai-tools
+codex plugin add agent-skills@ai-tools
+codex plugin add takt@ai-tools
+codex plugin add software-design@ai-tools
+```
+
+Verify the installation, then start a new Codex task so the installed plugins are loaded:
+
+```shell
+codex plugin list
 ```
 
 ### Agent Package Manager


### PR DESCRIPTION
## 概要

- `README.md` と `README.ja.md` に Codex Plugin のインストール方法を追加
- `j5ik2o/ai-tools` を Codex plugin marketplace として登録するコマンドを記載
- `git`、`github`、`agent-skills`、`takt`、`software-design` の導入コマンドを記載
- インストール結果の確認と、新しい Codex タスクでの再読み込みを案内
- リポジトリの説明と Highlights に Codex Plugin 対応を追記

## 背景

Codex向けの `.agents/plugins/marketplace.json` と各 `.codex-plugin/plugin.json` が利用可能になったため、利用者がルートREADMEだけでマーケットプレース登録からプラグイン導入まで進められるようにします。

## 影響

ドキュメントのみの変更です。既存のClaude Code、APM、スキルディレクトリ方式の導入手順には影響しません。

## 検証

- 一時的な `CODEX_HOME` で `codex plugin marketplace add j5ik2o/ai-tools --ref main` を実行
- `git@ai-tools`、`github@ai-tools`、`agent-skills@ai-tools`、`takt@ai-tools`、`software-design@ai-tools` の列挙を確認
- `npm run validate:codex-plugins` 成功
- `git diff --check` 成功

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime, config, or install-script changes.
> 
> **Overview**
> **README.md** and **README.ja.md** now describe Codex as a first-class distribution path alongside Claude Code, including a Highlights bullet for `.agents/plugins/marketplace.json`.
> 
> A new **Codex Plugin** section documents registering `j5ik2o/ai-tools` as a marketplace (`codex plugin marketplace add … --ref main`), installing `git`, `github`, `agent-skills`, `takt`, and `software-design`, and verifying with `codex plugin list` before starting a new Codex task so plugins load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92ced3c4abc27bba926834236fad03adbce8a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->