### PR TITLE
CI失敗がある場合の即時修正をPR収束スキルに明記する

### DIFF
--- a/plugins/github/skills/j5ik2o-gh-pr-converge-loop/SKILL.md
+++ b/plugins/github/skills/j5ik2o-gh-pr-converge-loop/SKILL.md
@@ -30,8 +30,8 @@ Use `gh pr checks` as the source of truth. It includes all PR-attached checks, w
 3. Invoke the `j5ik2o-gh-pr-review-follow-up` skill to inspect unresolved review threads, implement all unambiguous actionable fixes, and obtain any approval that skill requires before replying to or resolving threads.
 4. Validate, commit, and push accepted review fixes when the request authorizes those remote writes.
 5. Inspect the complete PR check set before waiting.
-6. If checks already failed, diagnose the failures, apply the smallest scoped fixes, validate, commit, and push them.
-7. If checks are pending, watch with `gh pr checks --watch --fail-fast`.
+6. If any check has failed, do not wait for other pending checks. Immediately diagnose the failures, apply the smallest scoped fixes, validate, commit, and push them.
+7. Only when no checks have failed and at least one check is pending, watch with `gh pr checks --watch --fail-fast`.
 8. After every push, return to step 1 before checking review feedback or CI again; finish only when the PR is mergeable, a final thread-aware review read finds no unresolved actionable feedback, and the complete required check set is green.
 
 ## Commands
@@ -60,6 +60,7 @@ gh run view <run-id> --log-failed
 - Do not inspect review feedback or wait on CI while base-branch conflicts remain unresolved.
 - Treat the `j5ik2o-gh-pr-resolve-conflicts` skill as the conflict-resolution and validation workflow. Keep its no-commit, no-push, and no-tag guardrail intact.
 - Before the first remote mutation, obtain explicit approval if the request does not already authorize comment replies, thread resolution, commits, and pushes.
+- Never wait for pending CI when any failure is already visible. A visible failure is immediately actionable and takes precedence over all pending checks.
 - Keep each fix scoped to a single failure cause when possible.
 - Do not bypass hooks (`--no-verify`) to force progress.
 - If the failure is clearly unrelated to the PR and appears fixed on the base branch, merge the latest base branch instead of bloating the PR with unrelated fixes.

--- a/plugins/github/skills/j5ik2o-gh-pr-converge-loop/agents/openai.yaml
+++ b/plugins/github/skills/j5ik2o-gh-pr-converge-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: 3dc523ff6235c43c89324fd80c18d4f0bbc35ac2e723bc2824eaae6b69d9aa73
+# skill-forge-source-sha256: 6eedf7a6c62894e79dae3a45bc8a64582c3b1db9470a31b650f9924fcfecd148
 interface:
   display_name: "GitHub PR Convergence Loop"
   short_description: "Loop until PR conflicts, feedback, and checks converge"


### PR DESCRIPTION
## 概要

`j5ik2o:gh-pr-converge-loop` に、CI失敗が確認できた場合は他のpendingチェックを待たず、即座に原因調査と修正へ進む規則を追加します。

## 背景

従来の手順では「失敗済みなら修正」「pendingなら待機」と記載されていましたが、failedとpendingが同時に存在する場合の優先順位が明示されていませんでした。そのため、既知のCIエラーがあるにもかかわらず、残りのCI完了を待つ解釈が可能でした。

## 変更内容

- failedが1件でもあれば、他のpendingチェックを待たず即座に修正へ進むよう明記
- CI待機を「failedが0件で、pendingが1件以上ある場合」に限定
- 同じ規則をガードレールにも追加
- `SKILL.md` の変更に合わせてCodexメタデータハッシュを更新

## 影響

PR収束ループで既知のCI失敗への対応開始が遅れることを防ぎます。CIがすべてpendingの場合の待機動作には変更ありません。

## 検証

- Claude向けスキル検証
- Codex向けスキル検証
- Codex厳格メタデータ検証
- 全Codexプラグインマニフェスト検証
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> エージェント向けスキル文書とメタデータハッシュのみの変更で、実行コードや認証・データ処理には触れていません。
> 
> **Overview**
> **`j5ik2o-gh-pr-converge-loop`** の CI 手順を、失敗と pending が同時にあるときの優先順位が曖昧にならないよう書き換えています。
> 
> ワークフローでは、**いずれかのチェックが failed のときは他の pending を待たず即修正**し、`gh pr checks --watch` は **failed がゼロで pending が残っている場合だけ**行うと明記しました。同じルールをガードレールにも追加し、Codex 用の `agents/openai.yaml` の `skill-forge-source-sha256` を `SKILL.md` に合わせて更新しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da221dc510cf77397b8bff98ccd8a3beaf7bc851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * GitHub PRの収束ワークフローを更新し、CIチェック失敗時は保留中のチェックを待たず、原因診断・最小限の修正・検証を優先する手順を明確化しました。
  * 失敗が確認されている場合に待機しないための運用ルールを追加しました。

* **Chores**
  * ワークフロー定義の整合性情報を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->