### PR TITLE
CI修正をローカルのフル検証前にpushする

### DIFF
--- a/plugins/github/skills/j5ik2o-gh-pr-converge-loop/SKILL.md
+++ b/plugins/github/skills/j5ik2o-gh-pr-converge-loop/SKILL.md
@@ -30,9 +30,10 @@ Use `gh pr checks` as the source of truth. It includes all PR-attached checks, w
 3. Invoke the `j5ik2o-gh-pr-review-follow-up` skill to inspect unresolved review threads, implement all unambiguous actionable fixes, and obtain any approval that skill requires before replying to or resolving threads.
 4. Validate, commit, and push accepted review fixes when the request authorizes those remote writes.
 5. Inspect the complete PR check set before waiting.
-6. If any check has failed, do not wait for other pending checks. Immediately diagnose the failures, apply the smallest scoped fixes, validate, commit, and push them.
-7. Only when no checks have failed and at least one check is pending, watch with `gh pr checks --watch --fail-fast`.
-8. After every push, return to step 1 before checking review feedback or CI again; finish only when the PR is mergeable, a final thread-aware review read finds no unresolved actionable feedback, and the complete required check set is green.
+6. If any check has failed, do not wait for other pending checks. Immediately diagnose the failures and apply the smallest scoped fixes. Run only the fast sanity checks needed to avoid an obviously invalid commit; do not wait for a full local build or test suite. Commit and push the fix immediately so CI restarts as soon as possible.
+7. Immediately after every push, start the relevant local build and tests as non-blocking work while CI runs. Continue inspecting CI without waiting for local validation. If local validation fails at any time, diagnose, fix, and push again without waiting for CI.
+8. After every push, return to step 1 while local validation continues. Only when no CI check or local validation has failed and at least one check is pending, watch with `gh pr checks --watch --fail-fast`.
+9. Finish only when the PR is mergeable, a final thread-aware review read finds no unresolved actionable feedback, the complete required check set is green, and relevant local validation has passed.
 
 ## Commands
 
@@ -61,6 +62,7 @@ gh run view <run-id> --log-failed
 - Treat the `j5ik2o-gh-pr-resolve-conflicts` skill as the conflict-resolution and validation workflow. Keep its no-commit, no-push, and no-tag guardrail intact.
 - Before the first remote mutation, obtain explicit approval if the request does not already authorize comment replies, thread resolution, commits, and pushes.
 - Never wait for pending CI when any failure is already visible. A visible failure is immediately actionable and takes precedence over all pending checks.
+- Do not make a full local build or test suite a pre-push gate for a known CI failure. Push the coherent minimal fix first, then run local validation in parallel with the restarted CI.
 - Keep each fix scoped to a single failure cause when possible.
 - Do not bypass hooks (`--no-verify`) to force progress.
 - If the failure is clearly unrelated to the PR and appears fixed on the base branch, merge the latest base branch instead of bloating the PR with unrelated fixes.

--- a/plugins/github/skills/j5ik2o-gh-pr-converge-loop/agents/openai.yaml
+++ b/plugins/github/skills/j5ik2o-gh-pr-converge-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
-# skill-forge-source-sha256: 6eedf7a6c62894e79dae3a45bc8a64582c3b1db9470a31b650f9924fcfecd148
+# skill-forge-source-sha256: 2775ab5879070de616acc2257b71752558580f046543a72bb320c5b5819b10d0
 interface:
   display_name: "GitHub PR Convergence Loop"
   short_description: "Loop until PR conflicts, feedback, and checks converge"


### PR DESCRIPTION
## 概要

`j5ik2o-gh-pr-converge-loop` のCI失敗解消フローを、ローカルのフルビルド・テスト完了後にpushする方式から、最小確認後に即pushしてCIとローカル検証を並行実行する方式へ変更します。

## 背景

既知のCI失敗を修正した後、ローカルのフルビルドや全テストの完了を待ってからpushすると、その間リモートCIを開始できず、PRがgreenになるまでの実時間が長くなります。

## 変更内容

- CI失敗修正後は、明らかに無効なコミットを防ぐ短時間の確認だけを実行
- フルビルド・テストを待たず、修正を即座にcommit・push
- push後にローカル検証を非ブロッキングで開始し、CI確認と並行実行
- ローカル検証またはCIのどちらかが失敗した時点で、もう一方を待たず修正・再push
- 完了条件にはCI成功と関連ローカル検証成功の両方を維持

## 影響

検証品質を落とさず、CI起動とローカル検証を重ねることで収束までの待ち時間を短縮します。

## push前の確認

- `git diff --check`
- push-first規則の機械的存在確認
- Codexメタデータハッシュの再生成

## push後の検証

- Claude/Codexスキル検証
- Codex厳格メタデータ検証
- 全Codexプラグインマニフェスト検証


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * CI失敗時に、最小限の修正・再実行を迅速に進める手順を追加しました。
  * プッシュ後のローカルビルド・テストとCI監視を並行して行う運用に更新しました。
  * CI失敗時に完全なローカル検証を待たず進めるルールを明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->